### PR TITLE
Day 1: Stop the bleeding (mount alias + 5 quick wins)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -167,6 +167,15 @@ function loadAllRoutes() {
     { path: '/api/templates',          file: 'routes/templateRoutes.js' },
     { path: '/api/pilot',              file: 'routes/pilotOutreachRoutes.js' },
     { path: '/api/vapi-call',          file: 'routes/vapiCallRoutes.js' },
+    // FIX 2026-04-28: Root-level fallback mount for dashboard handlers.
+    // Frontend dashboard.html calls absolute paths like /api/stats, /api/kones, /api/tasks,
+    // /api/ads, /api/trello/* which are defined inside dashboardRoute.js but were only
+    // reachable at /dashboard/api/* (mount prefix bug). These two entries register the
+    // SAME router files at root so the absolute paths resolve. Mounted LAST so all explicit
+    // prefix routes above (leadRoutes at /api/leads, dashboardRoutes-plural at /api/dashboard,
+    // etc.) still win first by Express registration order.
+    { path: '/',                       file: 'routes/pilotStatsPatch.js' },
+    { path: '/',                       file: 'routes/dashboardRoute.js' },
   ];
 
   const minheletRoutes = [
@@ -275,13 +284,23 @@ app.get('/health', async (req, res) => {
 
 app.get('/api/version', (req, res) => res.json({ version: VERSION, build: BUILD, mode: START_MODE }));
 
+// FIX 2026-04-28: Hot Opportunities filter (minIAI/maxIAI) was cosmetic.
+// The handler ignored query params, returning all rows regardless. Now wired to WHERE clause.
 app.get('/api/complexes', async (req, res) => {
   try {
-    const limit = parseInt(req.query.limit) || 100;
-    const { rows } = await pool.query(
-      `SELECT id, name, addresses as address, city, neighborhood, iai_score, enhanced_ssi_score as ssi_score, status, existing_units as units_count, developer
-       FROM complexes ORDER BY iai_score DESC NULLS LAST LIMIT $1`, [limit]
-    );
+    const limit = Math.min(parseInt(req.query.limit) || 100, 500);
+    const minIAI = parseFloat(req.query.minIAI);
+    const maxIAI = parseFloat(req.query.maxIAI);
+    const where = [];
+    const params = [];
+    if (!isNaN(minIAI)) { params.push(minIAI); where.push(`iai_score >= $${params.length}`); }
+    if (!isNaN(maxIAI)) { params.push(maxIAI); where.push(`iai_score <= $${params.length}`); }
+    params.push(limit);
+    const sql = `SELECT id, name, addresses as address, city, neighborhood, iai_score,
+        enhanced_ssi_score as ssi_score, status, existing_units as units_count, developer
+       FROM complexes ${where.length ? 'WHERE ' + where.join(' AND ') : ''}
+       ORDER BY iai_score DESC NULLS LAST LIMIT $${params.length}`;
+    const { rows } = await pool.query(sql, params);
     res.json(rows);
   } catch (err) { res.status(500).json({ error: err.message }); }
 });
@@ -308,6 +327,20 @@ app.get('/api/debug', async (req, res) => {
     outreach: JSON.stringify(outreachStats),
     newsletter: JSON.stringify(newsletterStats),
     routes: { loaded: loaded.map(r => `${r.path} (${r.file})`), failed: failed.map(r => ({ path: r.path, error: r.error })) }
+  });
+});
+
+// FIX 2026-04-28: Lightweight diagnostic endpoint exposing route load results.
+// Useful for quickly seeing which routes loaded vs failed without the full /api/debug payload.
+app.get('/api/_routes', (req, res) => {
+  res.json({
+    loaded: routeLoadResults.filter(r => r.status === 'ok').map(r => ({ path: r.path, file: r.file })),
+    failed: routeLoadResults.filter(r => r.status === 'failed').map(r => ({ path: r.path, file: r.file, error: r.error })),
+    counts: {
+      ok: routeLoadResults.filter(r => r.status === 'ok').length,
+      failed: routeLoadResults.filter(r => r.status === 'failed').length,
+      total: routeLoadResults.length
+    }
   });
 });
 
@@ -350,6 +383,20 @@ async function start() {
       cron.schedule('45 7 * * *',   async () => { try { await runKonesAutoContact(); } catch (e) {} });
       logger.info('[AutoContact] ACTIVE');
     } catch (e) { logger.warn('[AutoContact] Failed:', e.message); }
+
+    // FIX 2026-04-28: 86 of 100 complexes had null enhanced_ssi_score because
+    // /api/ssi/batch-aggregate was never scheduled. Daily run at 06:30 IL.
+    try {
+      const cron = require('node-cron');
+      const axios = require('axios');
+      cron.schedule('30 6 * * *', async () => {
+        try {
+          const r = await axios.post(`http://localhost:${PORT}/api/ssi/batch-aggregate`, {}, { timeout: 120000 });
+          logger.info('[SsiBatchAggregate] Daily run complete', { updated: r.data?.summary?.complexesUpdated, alerts: r.data?.summary?.alertsCreated });
+        } catch (e) { if (e.code !== 'ECONNREFUSED') logger.warn('[SsiBatchAggregate]', e.message); }
+      });
+      logger.info('[SsiBatchAggregate] ACTIVE - daily 06:30 IL');
+    } catch (e) { logger.warn('[SsiBatchAggregate] Failed:', e.message); }
 
     try {
       const cron = require('node-cron');

--- a/src/routes/facebookRoutes.js
+++ b/src/routes/facebookRoutes.js
@@ -9,6 +9,7 @@
  * POST /api/facebook/scan/all          - Batch scan all cities
  * GET  /api/facebook/stats             - Get scan statistics
  * GET  /api/facebook/listings          - Get Facebook listings
+ * GET  /api/facebook/ads                - Dashboard alias for active facebook listings (2026-04-28)
  * GET  /api/facebook/unmatched         - Get unmatched listings
  * GET  /api/facebook/cities            - Available cities with FB URLs
  * POST /api/facebook/match             - Manual listing→complex match
@@ -359,6 +360,52 @@ router.get('/listings', async (req, res) => {
   } catch (err) {
     logger.error('Facebook listings error', { error: err.message });
     res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * 2026-04-28: GET /ads - Dashboard alias.
+ *
+ * The dashboard frontend calls /api/facebook/ads which previously returned 500
+ * because no such handler existed and a stale code path referenced a
+ * non-existent `facebook_ads` table. The actual data is in `listings` with
+ * source='facebook'. This endpoint mirrors the dashboard's expected shape:
+ * { ads: [...] } where each row is a listing joined to its complex.
+ *
+ * Query params: city, urgent (true), limit (default 200, max 500).
+ */
+router.get('/ads', async (req, res) => {
+  try {
+    const { city, urgent } = req.query;
+    const limit = Math.min(parseInt(req.query.limit) || 200, 500);
+
+    const params = [];
+    const where = [`l.source = 'facebook'`, `l.is_active = TRUE`];
+    if (city)            { params.push(city);            where.push(`l.city = $${params.length}`); }
+    if (urgent === 'true') {
+      where.push(`(l.has_urgent_keywords = TRUE OR l.is_foreclosure = TRUE OR l.is_inheritance = TRUE)`);
+    }
+    params.push(limit);
+
+    const sql = `
+      SELECT l.id, l.title, l.address, l.city, l.rooms, l.area_sqm, l.asking_price,
+             l.price_per_sqm, l.url, l.phone, l.contact_name, l.thumbnail_url,
+             l.first_seen, l.last_seen, l.days_on_market,
+             l.has_urgent_keywords, l.is_foreclosure, l.is_inheritance,
+             l.ssi_score, l.complex_id,
+             c.name AS complex_name, c.iai_score, c.enhanced_ssi_score AS complex_ssi
+        FROM listings l
+        LEFT JOIN complexes c ON c.id = l.complex_id
+       WHERE ${where.join(' AND ')}
+       ORDER BY l.first_seen DESC NULLS LAST
+       LIMIT $${params.length}
+    `;
+
+    const { rows } = await pool.query(sql, params);
+    res.json({ success: true, ads: rows, total: rows.length });
+  } catch (err) {
+    logger.error('Facebook /ads error', { error: err.message });
+    res.status(500).json({ success: false, error: err.message });
   }
 });
 

--- a/src/routes/ssiRoutes.js
+++ b/src/routes/ssiRoutes.js
@@ -4,6 +4,7 @@
  * NEW: batch-aggregate (listing->complex), gov-enrich, dashboard data
  * v4.25.0: Expanded dashboard-data with enriched fields
  * v4.28.1: Fixed price_per_sqm -> accurate_price_sqm column name
+ * 2026-04-28: Added GET /stats alias for dashboard SSI panel
  */
 
 const express = require('express');
@@ -458,6 +459,35 @@ router.get('/status', (req, res) => {
     perplexityConfigured: !!process.env.PERPLEXITY_API_KEY,
     governmentApiAvailable: !!getGovernmentService()
   });
+});
+
+// =====================================================
+// 2026-04-28: GET /api/ssi/stats
+// Lightweight distribution stats for dashboard SSI panel.
+// Same buckets as /dashboard-data ssiDistribution, plus avg + missing count,
+// plus enriched_count to show how many complexes have SSI computed at all.
+// =====================================================
+router.get('/stats', async (req, res) => {
+  try {
+    const { rows } = await pool.query(`
+      SELECT
+        COUNT(*) AS total_complexes,
+        COUNT(*) FILTER (WHERE enhanced_ssi_score >= 80) AS critical,
+        COUNT(*) FILTER (WHERE enhanced_ssi_score >= 60 AND enhanced_ssi_score < 80) AS high,
+        COUNT(*) FILTER (WHERE enhanced_ssi_score >= 40 AND enhanced_ssi_score < 60) AS medium,
+        COUNT(*) FILTER (WHERE enhanced_ssi_score >= 20 AND enhanced_ssi_score < 40) AS low,
+        COUNT(*) FILTER (WHERE enhanced_ssi_score > 0 AND enhanced_ssi_score < 20) AS minimal,
+        COUNT(*) FILTER (WHERE COALESCE(enhanced_ssi_score, 0) = 0) AS missing,
+        COUNT(*) FILTER (WHERE enhanced_ssi_score > 0) AS enriched_count,
+        ROUND(AVG(enhanced_ssi_score) FILTER (WHERE enhanced_ssi_score > 0), 1) AS avg_ssi,
+        MAX(ssi_last_enhanced) AS last_enhanced
+      FROM complexes
+    `);
+    res.json({ success: true, ...rows[0] });
+  } catch (err) {
+    logger.error('SSI stats failed', { error: err.message });
+    res.status(500).json({ success: false, error: err.message });
+  }
 });
 
 // POST /api/ssi/enhance/:complexId


### PR DESCRIPTION
Day 1 fixes for the operator dashboard. 6 changes across 3 files.

## Root-cause discovery

dashboardRoute.js (the 161 KB monolith with /api/stats, /api/kones, /api/tasks x4, /api/ads, /api/trello/* x6) was only mounted at /dashboard. Frontend calls absolute /api/* and 404'd. Handlers actually lived at /dashboard/api/*. One line fixes 8 of 12 endpoints.

## Changes

1. src/index.js: add dual-mount at / for pilotStatsPatch.js + dashboardRoute.js, registered LAST in quantumRoutes[]. Closes 8 of 12 dashboard 404s.
2. src/index.js: wire minIAI / maxIAI into inline GET /api/complexes. Hot Opportunities filter now actually filters.
3. src/index.js: nightly cron 30 6 * * * for /api/ssi/batch-aggregate. Fixes 86/100 complexes with null SSI.
4. src/index.js: GET /api/_routes diagnostic.
5. src/routes/ssiRoutes.js: GET /api/ssi/stats. Returns bucket counts plus avg plus missing.
6. src/routes/facebookRoutes.js: GET /api/facebook/ads. Queries listings WHERE source='facebook'. Fixes 500 on facebook_ads relation missing.

## What did NOT change

No DB migrations, no new deps, no deletes. news cache already exists with 2h TTL, skipped. dashboardRoutes.js (plural) untouched.

## Smoke test after merge

- /api/_routes returns ok counts
- /api/stats returns 200
- /api/complexes?minIAI=80 returns fewer rows than /api/complexes
- /api/ssi/stats returns 200
- /api/facebook/ads returns 200
- /api/trello/board returns 200

## Risk

Low. No DB changes. No deletes. Dual-mount registered last so explicit prefix routes (leadRoutes, dashboardRoutes plural) win first by Express order.

## Roadmap

Day 1 of 7. Next: Day 2 chartRoutes plus system-status plus column key rename. Day 4-5 Match Engine v1. One PR per day, merge approval before each deploy.