### PR TITLE
Day 2: chartRoutes (4 endpoints) + system-status

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -141,6 +141,8 @@ function loadAllRoutes() {
     { path: '/api/alerts',             file: 'routes/alerts.js' },
     { path: '/api/leads',              file: 'routes/leadRoutes.js' },
     { path: '/api/dashboard',          file: 'routes/dashboardRoutes.js' },
+    // 2026-04-28 (Day 2): chartRoutes for /api/chart/* (4 endpoints) used by dashboard graphs.
+    { path: '/api/chart',              file: 'routes/chartRoutes.js' },
     { path: '/api/chat',               file: 'routes/chatRoutes.js' },
     { path: '/api/intelligence',       file: 'routes/intelligenceRoutes.js' },
     { path: '/api/facebook',           file: 'routes/facebookRoute.js' },

--- a/src/routes/chartRoutes.js
+++ b/src/routes/chartRoutes.js
@@ -1,0 +1,107 @@
+/**
+ * Chart Routes - Time-series and breakdowns for the dashboard.
+ * Created 2026-04-28 to close 4 dashboard 404s on /api/chart/*.
+ *
+ * All endpoints return { success, data } where data is an array (or object
+ * for the funnel) suitable for direct rendering. Each query is wrapped in
+ * safeQuery so a missing table yields an empty result instead of a 500.
+ */
+
+const express = require('express');
+const router = express.Router();
+const pool = require('../db/pool');
+const { logger } = require('../services/logger');
+
+async function safeQuery(sql, params = []) {
+  try {
+    const r = await pool.query(sql, params);
+    return r.rows;
+  } catch (err) {
+    logger.warn('[chartRoutes] query failed', { error: err.message, sql: sql.slice(0, 80) });
+    return [];
+  }
+}
+
+/**
+ * GET /api/chart/listings-monthly
+ * New listings per month for the last 12 months.
+ * Response: { success, data: [{ month: 'YYYY-MM', new_listings: N }, ...] }
+ */
+router.get('/listings-monthly', async (req, res) => {
+  const rows = await safeQuery(`
+    SELECT
+      TO_CHAR(date_trunc('month', first_seen), 'YYYY-MM') AS month,
+      COUNT(*)::int AS new_listings
+    FROM listings
+    WHERE first_seen >= NOW() - INTERVAL '12 months'
+    GROUP BY date_trunc('month', first_seen)
+    ORDER BY date_trunc('month', first_seen)
+  `);
+  res.json({ success: true, data: rows });
+});
+
+/**
+ * GET /api/chart/leads-by-source
+ * Distribution of leads by utm_source (falls back to source, then 'direct').
+ * Response: { success, data: [{ source: 'meta-ads', count: N }, ...] }
+ */
+router.get('/leads-by-source', async (req, res) => {
+  const rows = await safeQuery(`
+    SELECT
+      COALESCE(NULLIF(utm_source, ''), NULLIF(source, ''), 'direct') AS source,
+      COUNT(*)::int AS count
+    FROM leads
+    GROUP BY 1
+    ORDER BY count DESC
+    LIMIT 20
+  `);
+  res.json({ success: true, data: rows });
+});
+
+/**
+ * GET /api/chart/listings-by-source
+ * Active listings broken down by scraper source (yad2, facebook, dira, etc.).
+ * Response: { success, data: [{ source: 'yad2', count: N }, ...] }
+ */
+router.get('/listings-by-source', async (req, res) => {
+  const rows = await safeQuery(`
+    SELECT
+      COALESCE(NULLIF(source, ''), 'unknown') AS source,
+      COUNT(*)::int AS count
+    FROM listings
+    WHERE is_active = TRUE
+    GROUP BY 1
+    ORDER BY count DESC
+    LIMIT 20
+  `);
+  res.json({ success: true, data: rows });
+});
+
+/**
+ * GET /api/chart/conversion-rate
+ * Lead funnel summary: total -> engaged -> qualified -> converted.
+ * 'engaged' = status in (contacted, qualified, negotiation, closed)
+ * 'qualified' = status in (qualified, negotiation, closed)
+ * 'converted' = status = closed
+ * Response: { success, data: { total_leads, engaged, qualified, converted, conversion_rate_percent } }
+ */
+router.get('/conversion-rate', async (req, res) => {
+  const rows = await safeQuery(`
+    SELECT
+      COUNT(*)::int AS total_leads,
+      COUNT(*) FILTER (WHERE status IN ('contacted','qualified','negotiation','closed'))::int AS engaged,
+      COUNT(*) FILTER (WHERE status IN ('qualified','negotiation','closed'))::int AS qualified,
+      COUNT(*) FILTER (WHERE status = 'closed')::int AS converted,
+      COALESCE(ROUND(
+        COUNT(*) FILTER (WHERE status = 'closed')::numeric * 100.0 /
+        NULLIF(COUNT(*), 0)
+      , 2), 0)::float AS conversion_rate_percent
+    FROM leads
+  `);
+  const summary = rows[0] || {
+    total_leads: 0, engaged: 0, qualified: 0, converted: 0, conversion_rate_percent: 0
+  };
+  res.json({ success: true, data: summary });
+});
+
+module.exports = router;

--- a/src/routes/dashboardRoutes.js
+++ b/src/routes/dashboardRoutes.js
@@ -5,6 +5,7 @@
  *   - Complexes: ranked by TRUE investor premium (entry discount × theoretical premium)
  *   - Listings: ranked by SSI + investor context, known agents flagged
  *   - Construction-stage complexes deprioritized for investors
+ * 2026-04-28: Added /system-status for dashboard health panel.
  */
 
 const express = require('express');
@@ -19,6 +20,40 @@ const KNOWN_AGENT_PHONES = ['0508005958', '0508005971', '0508005995'];
 const CONSTRUCTION_STAGES = ['under_construction', 'ביצוע', 'בביצוע'];
 
 router.get('/', (req, res) => { res.redirect('/dashboard'); });
+
+// ============================================================
+// 2026-04-28: GET /api/dashboard/system-status
+// Lightweight system health for the dashboard top panel.
+// Each lookup wrapped so a missing table returns null, never 500.
+// ============================================================
+router.get('/system-status', async (req, res) => {
+  const safe = async (sql) => {
+    try { const r = await pool.query(sql); return r.rows[0]; } catch (e) { return null; }
+  };
+  try {
+    const [c, l, le, lc, ll] = await Promise.all([
+      safe(`SELECT COUNT(*)::int AS n FROM complexes`),
+      safe(`SELECT COUNT(*)::int AS n FROM listings WHERE is_active = TRUE`),
+      safe(`SELECT COUNT(*)::int AS n FROM leads`),
+      safe(`SELECT MAX(updated_at) AS ts FROM complexes`),
+      safe(`SELECT MAX(last_seen) AS ts FROM listings`)
+    ]);
+    res.json({
+      ok: true,
+      db: 'up',
+      mode: (process.env.START_MODE || 'both').toLowerCase(),
+      uptime_sec: Math.round(process.uptime()),
+      complexes: c?.n ?? null,
+      active_listings: l?.n ?? null,
+      leads: le?.n ?? null,
+      last_complex_update: lc?.ts ?? null,
+      last_listing_seen: ll?.ts ?? null,
+      timestamp: new Date().toISOString()
+    });
+  } catch (err) {
+    res.status(503).json({ ok: false, db: 'error', error: err.message });
+  }
+});
 
 // ============================================================
 // API: All Ads — with true investor premium per listing


### PR DESCRIPTION
Day 2 fixes. 5 new endpoints, 1 new file, 2 file edits.

## Changes

1. New file src/routes/chartRoutes.js with 4 endpoints under /api/chart:
   - listings-monthly: new listings per month, last 12 months
   - leads-by-source: count by utm or source falling back to direct
   - listings-by-source: active listings by scraper source
   - conversion-rate: lead funnel summary plus percent
2. src/index.js: mount chartRoutes at /api/chart inside quantumRoutes after /api/dashboard
3. src/routes/dashboardRoutes.js: append GET /system-status returning row counts, last update timestamps, uptime, mode

## Defensive design

Each chart query wrapped in safeQuery so a missing table yields empty array instead of 500. system-status uses Promise.all with per-query try/catch.

## What did NOT change

No DB migrations. No new deps. No deletes. dashboard.html column rename still deferred until I can verify post-Day-1 rendering.

## Risk

Low. New endpoints only. No edits to existing handlers. chartRoutes is brand new. dashboardRoutes.js gets one new sub-route appended near top.

## Roadmap

Day 2 of 7. Next: Day 3 Lead inbox revamp.