### PR TITLE
Day 3: Lead pipeline endpoint + real leads/stats query

### DIFF
--- a/src/routes/dashboardRoutes.js
+++ b/src/routes/dashboardRoutes.js
@@ -7,6 +7,7 @@
  *   - Construction-stage complexes deprioritized for investors
  * 2026-04-28: Added /system-status for dashboard health panel.
  * 2026-04-28: Replaced hardcoded /leads/stats with real query against website_leads.
+ * 2026-04-28: Added backward-compat aliases on /leads/stats response.
  */
 
 const express = require('express');
@@ -223,8 +224,10 @@ router.get('/news', (req, res) => res.json({ news: [] }));
 router.get('/calls/stats', (req, res) => res.json({ today: { total: 0 }, week: { total: 0 }, month: { total: 0 } }));
 
 // 2026-04-28: was hardcoded zeros, now queries website_leads.
-// Fields: total, new (status=new), contacted, qualified, negotiation, closed,
-// lost, urgent, this_month, last_24h, with_trello, conversion_rate (closed/total*100).
+// Returns: total, new (status=new), contacted, qualified, negotiation, closed,
+// lost, urgent, this_month, last_24h, last_7d, with_trello, conversion_rate,
+// PLUS backward-compat aliases new_this_month, converted, active for any
+// frontend code reading the prior shape.
 router.get('/leads/stats', async (req, res) => {
   try {
     const { rows } = await pool.query(`
@@ -247,12 +250,20 @@ router.get('/leads/stats', async (req, res) => {
         , 2), 0)::float AS conversion_rate
       FROM website_leads
     `);
-    res.json(rows[0]);
+    const r = rows[0];
+    res.json({
+      ...r,
+      // Backward-compat aliases for the prior hardcoded response shape.
+      new_this_month: r.this_month,
+      converted: r.closed,
+      active: r.new + r.contacted + r.qualified + r.negotiation
+    });
   } catch (err) {
-    // Table may not exist on a fresh DB. Return zeros with a hint instead of 500.
+    // Table may not exist on a fresh DB. Return zeros (with aliases) instead of 500.
     res.json({
       total: 0, new: 0, contacted: 0, qualified: 0, negotiation: 0, closed: 0, lost: 0,
       urgent: 0, this_month: 0, last_24h: 0, last_7d: 0, with_trello: 0, conversion_rate: 0,
+      new_this_month: 0, converted: 0, active: 0,
       note: 'website_leads table not ready'
     });
   }

--- a/src/routes/dashboardRoutes.js
+++ b/src/routes/dashboardRoutes.js
@@ -6,6 +6,7 @@
  *   - Listings: ranked by SSI + investor context, known agents flagged
  *   - Construction-stage complexes deprioritized for investors
  * 2026-04-28: Added /system-status for dashboard health panel.
+ * 2026-04-28: Replaced hardcoded /leads/stats with real query against website_leads.
  */
 
 const express = require('express');
@@ -34,7 +35,7 @@ router.get('/system-status', async (req, res) => {
     const [c, l, le, lc, ll] = await Promise.all([
       safe(`SELECT COUNT(*)::int AS n FROM complexes`),
       safe(`SELECT COUNT(*)::int AS n FROM listings WHERE is_active = TRUE`),
-      safe(`SELECT COUNT(*)::int AS n FROM leads`),
+      safe(`SELECT COUNT(*)::int AS n FROM website_leads`),
       safe(`SELECT MAX(updated_at) AS ts FROM complexes`),
       safe(`SELECT MAX(last_seen) AS ts FROM listings`)
     ]);
@@ -220,7 +221,42 @@ router.get('/complexes/all', async (req, res) => {
 router.get('/buyers/all', (req, res) => res.json({ buyers: [] }));
 router.get('/news', (req, res) => res.json({ news: [] }));
 router.get('/calls/stats', (req, res) => res.json({ today: { total: 0 }, week: { total: 0 }, month: { total: 0 } }));
-router.get('/leads/stats', (req, res) => res.json({ total: 0, new_this_month: 0, converted: 0, active: 0, conversion_rate: 0 }));
+
+// 2026-04-28: was hardcoded zeros, now queries website_leads.
+// Fields: total, new (status=new), contacted, qualified, negotiation, closed,
+// lost, urgent, this_month, last_24h, with_trello, conversion_rate (closed/total*100).
+router.get('/leads/stats', async (req, res) => {
+  try {
+    const { rows } = await pool.query(`
+      SELECT
+        COUNT(*)::int AS total,
+        COUNT(*) FILTER (WHERE status = 'new')::int AS new,
+        COUNT(*) FILTER (WHERE status = 'contacted')::int AS contacted,
+        COUNT(*) FILTER (WHERE status = 'qualified')::int AS qualified,
+        COUNT(*) FILTER (WHERE status = 'negotiation')::int AS negotiation,
+        COUNT(*) FILTER (WHERE status = 'closed')::int AS closed,
+        COUNT(*) FILTER (WHERE status = 'lost')::int AS lost,
+        COUNT(*) FILTER (WHERE is_urgent = TRUE)::int AS urgent,
+        COUNT(*) FILTER (WHERE created_at > date_trunc('month', NOW()))::int AS this_month,
+        COUNT(*) FILTER (WHERE created_at > NOW() - INTERVAL '24 hours')::int AS last_24h,
+        COUNT(*) FILTER (WHERE created_at > NOW() - INTERVAL '7 days')::int AS last_7d,
+        COUNT(*) FILTER (WHERE trello_card_id IS NOT NULL)::int AS with_trello,
+        COALESCE(ROUND(
+          COUNT(*) FILTER (WHERE status = 'closed')::numeric * 100.0 /
+          NULLIF(COUNT(*), 0)
+        , 2), 0)::float AS conversion_rate
+      FROM website_leads
+    `);
+    res.json(rows[0]);
+  } catch (err) {
+    // Table may not exist on a fresh DB. Return zeros with a hint instead of 500.
+    res.json({
+      total: 0, new: 0, contacted: 0, qualified: 0, negotiation: 0, closed: 0, lost: 0,
+      urgent: 0, this_month: 0, last_24h: 0, last_7d: 0, with_trello: 0, conversion_rate: 0,
+      note: 'website_leads table not ready'
+    });
+  }
+});
 
 // API: Get single complex
 router.get('/complex/:id', async (req, res) => {

--- a/src/routes/leadRoutes.js
+++ b/src/routes/leadRoutes.js
@@ -3,12 +3,14 @@
  * POST /submit - Receive lead from website
  * GET / - List leads (filters: type, status, urgent)
  * GET /stats - Lead statistics
+ * GET /pipeline - Status-grouped pipeline view (added 2026-04-28)
  * PUT /:id/status - Update lead status
  * GET /trello/status - Trello integration status
  */
 
 const express = require('express');
 const router = express.Router();
+const pool = require('../db/pool');
 const { logger } = require('../services/logger');
 
 let leadService;
@@ -125,6 +127,104 @@ router.get('/stats', async (req, res) => {
   } catch (error) {
     logger.error('Lead stats error:', error.message);
     res.status(500).json({ error: error.message });
+  }
+});
+
+/**
+ * 2026-04-28: GET /pipeline
+ * Status-grouped pipeline view for the dashboard Lead inbox.
+ * Returns counts by status, counts by user_type, urgent count, 24h/7d/30d
+ * cohorts, plus last 5 leads per status with trello_card_url + parsed
+ * form_data preview.
+ */
+router.get('/pipeline', async (req, res) => {
+  try {
+    if (leadService && leadService.ensureLeadsTable) {
+      try { await leadService.ensureLeadsTable(); } catch (e) { /* table may already exist */ }
+    }
+
+    const safe = async (sql, params = []) => {
+      try { const r = await pool.query(sql, params); return r.rows; } catch (e) {
+        logger.warn('[leads/pipeline] query failed', { error: e.message });
+        return [];
+      }
+    };
+
+    const STATUSES = ['new', 'contacted', 'qualified', 'negotiation', 'closed', 'lost'];
+
+    const [byStatus, byType, cohorts, recentByStatus] = await Promise.all([
+      safe(`
+        SELECT status, COUNT(*)::int AS count
+        FROM website_leads
+        GROUP BY status
+      `),
+      safe(`
+        SELECT user_type, COUNT(*)::int AS count
+        FROM website_leads
+        GROUP BY user_type
+      `),
+      safe(`
+        SELECT
+          COUNT(*)::int AS total,
+          COUNT(*) FILTER (WHERE is_urgent = TRUE)::int AS urgent,
+          COUNT(*) FILTER (WHERE created_at > NOW() - INTERVAL '24 hours')::int AS last_24h,
+          COUNT(*) FILTER (WHERE created_at > NOW() - INTERVAL '7 days')::int AS last_7d,
+          COUNT(*) FILTER (WHERE created_at > NOW() - INTERVAL '30 days')::int AS last_30d,
+          COUNT(*) FILTER (WHERE trello_card_id IS NOT NULL)::int AS with_trello
+        FROM website_leads
+      `),
+      safe(`
+        SELECT id, name, phone, email, user_type, status, is_urgent,
+               trello_card_url, form_data, created_at, updated_at,
+               campaign_tag, utm_source
+        FROM (
+          SELECT *, ROW_NUMBER() OVER (PARTITION BY status ORDER BY created_at DESC) AS rn
+          FROM website_leads
+        ) t
+        WHERE t.rn <= 5
+        ORDER BY status, created_at DESC
+      `)
+    ]);
+
+    // Normalize: ensure every status appears even with 0 count.
+    const statusMap = Object.fromEntries(STATUSES.map(s => [s, 0]));
+    byStatus.forEach(r => { if (r.status) statusMap[r.status] = r.count; });
+
+    // Group recent leads by status.
+    const recentMap = Object.fromEntries(STATUSES.map(s => [s, []]));
+    recentByStatus.forEach(l => {
+      const s = l.status || 'new';
+      if (!recentMap[s]) recentMap[s] = [];
+      // Parse form_data if it came back as string.
+      let fd = l.form_data;
+      if (typeof fd === 'string') {
+        try { fd = JSON.parse(fd); } catch (e) { fd = {}; }
+      }
+      recentMap[s].push({
+        id: l.id, name: l.name, phone: l.phone, email: l.email,
+        user_type: l.user_type, is_urgent: l.is_urgent,
+        trello_card_url: l.trello_card_url,
+        campaign_tag: l.campaign_tag, utm_source: l.utm_source,
+        form_data_preview: fd,
+        created_at: l.created_at, updated_at: l.updated_at
+      });
+    });
+
+    // by_type as object {investor: N, owner: N, contact: N, ...}
+    const typeMap = {};
+    byType.forEach(r => { if (r.user_type) typeMap[r.user_type] = r.count; });
+
+    res.json({
+      success: true,
+      cohorts: cohorts[0] || { total: 0, urgent: 0, last_24h: 0, last_7d: 0, last_30d: 0, with_trello: 0 },
+      by_status: statusMap,
+      by_type: typeMap,
+      recent_by_status: recentMap,
+      generated_at: new Date().toISOString()
+    });
+  } catch (error) {
+    logger.error('Lead pipeline error:', error.message);
+    res.status(500).json({ success: false, error: error.message });
   }
 });
 


### PR DESCRIPTION
Day 3 fixes for the Lead inbox.

## Changes

1. New endpoint GET /api/leads/pipeline in src/routes/leadRoutes.js. Returns:
   - cohorts: total, urgent, last_24h, last_7d, last_30d, with_trello
   - by_status: counts per status (new, contacted, qualified, negotiation, closed, lost). Always returns all 6 statuses even with 0 count.
   - by_type: counts per user_type (investor, owner, contact)
   - recent_by_status: last 5 leads per status with id, name, phone, email, user_type, is_urgent, trello_card_url, campaign_tag, utm_source, parsed form_data preview, created_at, updated_at.

2. Replaced hardcoded /api/dashboard/leads/stats in src/routes/dashboardRoutes.js. Was returning zeros for everything. Now queries website_leads with COUNT FILTER buckets and computes conversion_rate as closed / total.

## Defensive design

Pipeline endpoint uses safe() wrapper around each query so any missing column or table yields empty result instead of 500. /leads/stats catches table-missing errors and returns zero-row defaults.

## Schema referenced

website_leads: id, name, email, phone, phone_verified, user_type (investor / owner / contact), form_data JSONB, mailing_list_consent, source, is_urgent, trello_card_id, trello_card_url, email_sent, notes, status, created_at, updated_at, campaign_tag, utm_source, utm_campaign.

## Risk

Low. New endpoint is additive. The /leads/stats replacement keeps the same URL and response shape (just real numbers instead of zeros). No DB migrations, no new deps.

## Roadmap

Day 3 of 7. Next: Day 4-5 Match Engine v1.