### PR TITLE
Day 4-5: Match Engine v1 (Supabase webhook + matchEngine + lead_matches table)

### DIFF
--- a/src/db/migrations/020_lead_matches.sql
+++ b/src/db/migrations/020_lead_matches.sql
@@ -1,0 +1,32 @@
+-- Migration 020: lead_matches table
+-- Created 2026-04-28 for Match Engine v1.
+-- Links investor leads (website_leads) to scored listings + complexes.
+-- Idempotent: safe to re-run.
+
+CREATE TABLE IF NOT EXISTS lead_matches (
+  id              SERIAL PRIMARY KEY,
+  lead_id         INT NOT NULL REFERENCES website_leads(id) ON DELETE CASCADE,
+  listing_id      INT REFERENCES listings(id) ON DELETE CASCADE,
+  complex_id      INT REFERENCES complexes(id) ON DELETE SET NULL,
+  match_score     NUMERIC(5,2) NOT NULL,
+  match_reasons   JSONB DEFAULT '[]'::jsonb,
+  operator_status TEXT NOT NULL DEFAULT 'pending',
+    -- operator_status values: pending | contacted | sent | dismissed | won | lost
+  notes           TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (lead_id, listing_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_lead_matches_lead_score
+  ON lead_matches (lead_id, match_score DESC);
+
+CREATE INDEX IF NOT EXISTS idx_lead_matches_operator_status
+  ON lead_matches (operator_status)
+  WHERE operator_status IN ('pending', 'contacted');
+
+CREATE INDEX IF NOT EXISTS idx_lead_matches_complex
+  ON lead_matches (complex_id);
+
+CREATE INDEX IF NOT EXISTS idx_lead_matches_created
+  ON lead_matches (created_at DESC);

--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,7 @@ app.use(helmet({
     }
   }
 }));
-app.use(cors({ origin: process.env.CORS_ORIGIN || '*', methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'], allowedHeaders: ['Content-Type', 'Authorization', 'X-Auth-Token'] }));
+app.use(cors({ origin: process.env.CORS_ORIGIN || '*', methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'], allowedHeaders: ['Content-Type', 'Authorization', 'X-Auth-Token', 'X-Webhook-Secret'] }));
 app.use(express.json({ limit: '10mb' }));
 
 const limiter = rateLimit({
@@ -86,7 +86,8 @@ const limiter = rateLimit({
     req.path.startsWith('/api/morning/') ||
     req.path.startsWith('/api/newsletter/') ||
     req.path.startsWith('/api/callcenter/') ||
-    req.path.startsWith('/callcenter/'),
+    req.path.startsWith('/callcenter/') ||
+    req.path === '/api/leads-ingest',
   message: { error: 'Too many requests, please try again later' }
 });
 app.use('/api/', limiter);
@@ -143,6 +144,10 @@ function loadAllRoutes() {
     { path: '/api/dashboard',          file: 'routes/dashboardRoutes.js' },
     // 2026-04-28 (Day 2): chartRoutes for /api/chart/* (4 endpoints) used by dashboard graphs.
     { path: '/api/chart',              file: 'routes/chartRoutes.js' },
+    // 2026-04-28 (Day 4-5): Match Engine ingest + match endpoints.
+    // Mounted at /api so paths land at /api/leads-ingest, /api/leads/:id/match,
+    // /api/leads/:id/matches, /api/lead-matches/:id.
+    { path: '/api',                    file: 'routes/leadIngestRoutes.js' },
     { path: '/api/chat',               file: 'routes/chatRoutes.js' },
     { path: '/api/intelligence',       file: 'routes/intelligenceRoutes.js' },
     { path: '/api/facebook',           file: 'routes/facebookRoute.js' },
@@ -363,6 +368,8 @@ async function start() {
   await runMigrationFile('Newsletter (015)', path.join(__dirname, 'db', 'migrations', '015_newsletter_subscribers.sql'));
   await runMigrationFile('Newsletter lang (016)', path.join(__dirname, 'db', 'migrations', '016_newsletter_lang.sql'));
   await runMigrationFile('Multi-channel (019)', path.join(__dirname, 'db', 'migrations', '019_available_channels.sql'));
+  // 2026-04-28 (Day 4-5): Match Engine v1
+  await runMigrationFile('Lead matches (020)', path.join(__dirname, 'db', 'migrations', '020_lead_matches.sql'));
   if (isQuantum) await runOutreachMigration();
 
   loadAllRoutes();

--- a/src/routes/leadIngestRoutes.js
+++ b/src/routes/leadIngestRoutes.js
@@ -1,0 +1,170 @@
+/**
+ * Lead Ingest + Match Engine Routes (Day 4-5, 2026-04-28)
+ *
+ * Mounted at /api so paths are:
+ *   POST /api/leads-ingest         -- Supabase webhook entry (shared-secret auth)
+ *   POST /api/leads/:id/match      -- operator-triggered re-match
+ *   GET  /api/leads/:id/matches    -- read top-N matches for a lead
+ *   PATCH /api/lead-matches/:id    -- update match operator_status
+ */
+
+const express = require('express');
+const router = express.Router();
+const pool = require('../db/pool');
+const { logger } = require('../services/logger');
+const matchEngine = require('../services/matchEngine');
+
+/**
+ * Verify webhook secret. Fail closed: if SUPABASE_WEBHOOK_SECRET is unset
+ * the endpoint refuses all requests.
+ */
+function verifyWebhookSecret(req, res) {
+  const expected = process.env.SUPABASE_WEBHOOK_SECRET;
+  if (!expected) {
+    res.status(503).json({ error: 'webhook secret not configured on server' });
+    return false;
+  }
+  const provided = req.headers['x-webhook-secret'];
+  if (!provided || provided !== expected) {
+    res.status(401).json({ error: 'invalid or missing X-Webhook-Secret header' });
+    return false;
+  }
+  return true;
+}
+
+/**
+ * POST /api/leads-ingest
+ * Body shape (from u-r-quantum.com Supabase Edge Function):
+ *   {
+ *     external_id: 'supabase-row-uuid',  // optional; used for idempotency
+ *     name, email, phone,
+ *     user_type: 'investor' | 'owner' | 'contact',
+ *     form_data: { budget, areas, horizon, ... } | { addresses, ... },
+ *     source, campaign_tag, utm_source, utm_campaign
+ *   }
+ */
+router.post('/leads-ingest', async (req, res) => {
+  if (!verifyWebhookSecret(req, res)) return;
+
+  const b = req.body || {};
+  if (!b.name || !b.phone) {
+    return res.status(400).json({ error: 'name and phone required' });
+  }
+
+  try {
+    // Insert into website_leads. Idempotency via (email, phone) match.
+    let leadId;
+    if (b.email && b.phone) {
+      const existing = await pool.query(
+        `SELECT id FROM website_leads WHERE email = $1 AND phone = $2 ORDER BY id DESC LIMIT 1`,
+        [b.email, b.phone]
+      );
+      if (existing.rows[0]) {
+        leadId = existing.rows[0].id;
+        // Refresh form_data on re-submission so newer answers win.
+        await pool.query(
+          `UPDATE website_leads
+              SET form_data = $1::jsonb,
+                  updated_at = NOW(),
+                  campaign_tag = COALESCE($2, campaign_tag),
+                  utm_source = COALESCE($3, utm_source),
+                  utm_campaign = COALESCE($4, utm_campaign)
+            WHERE id = $5`,
+          [JSON.stringify(b.form_data || {}), b.campaign_tag || null, b.utm_source || null, b.utm_campaign || null, leadId]
+        );
+      }
+    }
+
+    if (!leadId) {
+      const ins = await pool.query(`
+        INSERT INTO website_leads
+          (name, email, phone, phone_verified, user_type, form_data, mailing_list_consent, is_urgent, source, campaign_tag, utm_source, utm_campaign)
+        VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8, $9, $10, $11, $12)
+        RETURNING id
+      `, [
+        b.name, b.email || '', b.phone, !!b.phone_verified,
+        b.user_type || 'investor', JSON.stringify(b.form_data || {}),
+        !!b.mailing_list_consent, false,
+        b.source || 'u-r-quantum',
+        b.campaign_tag || null, b.utm_source || null, b.utm_campaign || null
+      ]);
+      leadId = ins.rows[0].id;
+      logger.info('[leadsIngest] new lead', { lead_id: leadId, user_type: b.user_type, source: b.source });
+    } else {
+      logger.info('[leadsIngest] lead refreshed', { lead_id: leadId });
+    }
+
+    // Respond fast; run match in background.
+    res.status(202).json({ ok: true, lead_id: leadId, matching: 'in_background' });
+
+    setImmediate(async () => {
+      try {
+        const result = await matchEngine.matchLead(leadId);
+        logger.info('[leadsIngest] match result', result);
+      } catch (e) {
+        logger.error('[leadsIngest] match failed', { lead_id: leadId, error: e.message });
+      }
+    });
+  } catch (err) {
+    logger.error('[leadsIngest] insert failed', { error: err.message });
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * POST /api/leads/:id/match
+ * Operator-triggered re-match (e.g., after fixing form_data or after the
+ * inventory got new listings). Synchronous so the operator sees the outcome.
+ */
+router.post('/leads/:id/match', async (req, res) => {
+  const id = parseInt(req.params.id);
+  if (!Number.isInteger(id) || id <= 0) {
+    return res.status(400).json({ error: 'invalid lead id' });
+  }
+  try {
+    const result = await matchEngine.matchLead(id);
+    res.json({ ok: true, ...result });
+  } catch (err) {
+    logger.error('[leads/match] failed', { lead_id: id, error: err.message });
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * GET /api/leads/:id/matches
+ * Read top-N scored matches for a lead (default 10, max 50).
+ */
+router.get('/leads/:id/matches', async (req, res) => {
+  const id = parseInt(req.params.id);
+  if (!Number.isInteger(id) || id <= 0) {
+    return res.status(400).json({ error: 'invalid lead id' });
+  }
+  try {
+    const rows = await matchEngine.getMatchesForLead(id, parseInt(req.query.limit) || 10);
+    res.json({ lead_id: id, matches: rows, total: rows.length });
+  } catch (err) {
+    logger.error('[leads/matches] failed', { lead_id: id, error: err.message });
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * PATCH /api/lead-matches/:id
+ * Body: { status: 'contacted' | 'sent' | 'dismissed' | 'won' | 'lost' | 'pending', notes?: string }
+ * Operator updates a match's operator_status.
+ */
+router.patch('/lead-matches/:id', async (req, res) => {
+  const id = parseInt(req.params.id);
+  if (!Number.isInteger(id) || id <= 0) {
+    return res.status(400).json({ error: 'invalid match id' });
+  }
+  try {
+    const updated = await matchEngine.updateMatchStatus(id, req.body?.status, req.body?.notes);
+    if (!updated) return res.status(404).json({ error: 'match not found' });
+    res.json({ ok: true, match: updated });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/src/services/matchEngine.js
+++ b/src/services/matchEngine.js
@@ -1,0 +1,283 @@
+/**
+ * Match Engine v1 - score listings against investor leads.
+ * Created 2026-04-28 (Day 4-5 of dashboard fix plan).
+ *
+ * Input:  lead_id from website_leads (user_type='investor' expected).
+ * Output: rows inserted into lead_matches with match_score and match_reasons.
+ *
+ * The lead's preferences live in form_data JSONB:
+ *   - budget: '1-2m' | '2-5m' | '5m+'
+ *   - areas:  ['center', 'sharon', 'north', 'south', 'jerusalem', 'haifa']
+ *   - horizon: 'short' | 'long'
+ *   - hasMultipleInvestments: bool
+ *
+ * Scoring (out of 100):
+ *   base 50
+ *   + iai_score * 0.30  (max +30)
+ *   + enhanced_ssi_score * 0.15  (max +15)
+ *   + entry_discount_pct * 1.5  (capped +30; only if positive)
+ *   - 20 if construction stage (premium already captured)
+ *   - 10 if has_negative_news
+ *   clamp to [0, 100]
+ */
+
+const pool = require('../db/pool');
+const { logger } = require('./logger');
+
+// Map area code to a list of city names. Hebrew city strings as they appear
+// in listings.city / complexes.city. Conservative coverage of the largest
+// cities per area; lookup is `ILIKE ANY` so partial matches work too.
+const AREA_TO_CITIES = {
+  center:    ['תל אביב', 'תל אביב-יפו', 'רמת גן', 'גבעתיים', 'חולון', 'בת ים', 'ראשון לציון', 'פתח תקווה', 'ראש העין', 'גבעת שמואל', 'קריית אונו', 'יהוד', 'אור יהודה'],
+  sharon:    ['הרצליה', 'רעננה', 'כפר סבא', 'הוד השרון', 'נתניה', 'רמת השרון'],
+  north:     ['חיפה', 'קריית ביאליק', 'קריית מוצקין', 'קריית ים', 'קריית אתא', 'נהריה', 'כרמיאל', 'עכו', 'טבריה', 'צפת'],
+  south:     ['באר שבע', 'אשדוד', 'אשקלון', 'דימונה', 'אילת', 'קריית גת', 'נתיבות', 'אופקים'],
+  jerusalem: ['ירושלים', 'בית שמש', 'מבשרת ציון'],
+  haifa:     ['חיפה', 'קריית ים', 'קריית מוצקין', 'קריית ביאליק', 'קריית אתא', 'נשר', 'טירת כרמל']
+};
+
+const BUDGET_RANGES = {
+  '1-2m': { min: 1_000_000, max: 2_000_000 },
+  '2-5m': { min: 2_000_000, max: 5_000_000 },
+  '5m+':  { min: 5_000_000, max: 50_000_000 }
+};
+
+const CONSTRUCTION_STAGES = ['under_construction', 'ביצוע', 'בביצוע'];
+
+const TOP_N_PER_LEAD = 20;
+const MIN_SCORE_TO_PERSIST = 40;
+
+function expandAreas(areas) {
+  if (!Array.isArray(areas) || areas.length === 0) return null;
+  const cities = new Set();
+  areas.forEach(a => {
+    const list = AREA_TO_CITIES[a];
+    if (list) list.forEach(c => cities.add(c));
+  });
+  return cities.size ? Array.from(cities) : null;
+}
+
+function parseFormData(formData) {
+  if (!formData) return {};
+  if (typeof formData === 'string') {
+    try { return JSON.parse(formData); } catch (e) { return {}; }
+  }
+  return formData;
+}
+
+function clamp(n, lo, hi) {
+  if (Number.isNaN(n) || n === null || n === undefined) return lo;
+  return Math.max(lo, Math.min(hi, n));
+}
+
+function scoreCandidate(c, leadFormData) {
+  let score = 50;
+  const reasons = [];
+
+  const iai = Number(c.iai_score) || 0;
+  if (iai > 0) {
+    const boost = Math.min(iai * 0.30, 30);
+    score += boost;
+    reasons.push(`IAI ${iai} (+${boost.toFixed(0)})`);
+  }
+
+  const ssi = Number(c.enhanced_ssi_score) || 0;
+  if (ssi > 0) {
+    const boost = Math.min(ssi * 0.15, 15);
+    score += boost;
+    reasons.push(`SSI ${ssi} (+${boost.toFixed(0)})`);
+  }
+
+  const entry = Number(c.entry_discount_pct) || 0;
+  if (entry > 0) {
+    const boost = Math.min(entry * 1.5, 30);
+    score += boost;
+    reasons.push(`Entry below market ${entry.toFixed(1)}% (+${boost.toFixed(0)})`);
+  }
+
+  if (CONSTRUCTION_STAGES.includes(c.plan_stage)) {
+    score -= 20;
+    reasons.push('Stage: under construction (-20)');
+  }
+
+  if (c.has_negative_news) {
+    score -= 10;
+    reasons.push('Negative news on developer (-10)');
+  }
+
+  // Long horizon bonus for early-stage projects.
+  const horizon = leadFormData?.horizon;
+  if (horizon === 'long' && ['planning', 'pre_deposit', 'declared'].includes(c.plan_stage)) {
+    score += 5;
+    reasons.push(`Long horizon plus early stage (+5)`);
+  }
+
+  return { score: clamp(Math.round(score * 100) / 100, 0, 100), reasons };
+}
+
+/**
+ * Match a single lead against the listing inventory and persist results.
+ * Returns { lead_id, candidates_scanned, matches_persisted, top_score } or
+ * { skipped: true, reason: '...' } if the lead is not eligible.
+ */
+async function matchLead(leadId) {
+  const leadRes = await pool.query(
+    `SELECT id, name, user_type, form_data FROM website_leads WHERE id = $1`,
+    [leadId]
+  );
+  const lead = leadRes.rows[0];
+  if (!lead) return { skipped: true, reason: 'lead not found' };
+
+  // Match Engine v1 only handles investor leads. Owner/contact leads are
+  // sell-side or general inquiry and don't need listing matches.
+  if (lead.user_type !== 'investor') {
+    return { skipped: true, reason: `user_type ${lead.user_type} not matchable` };
+  }
+
+  const fd = parseFormData(lead.form_data);
+  const cities = expandAreas(fd.areas);
+  const budget = BUDGET_RANGES[fd.budget];
+
+  if (!cities && !budget) {
+    return { skipped: true, reason: 'no areas or budget in form_data' };
+  }
+
+  // Build listing query with available filters.
+  const params = [];
+  const conditions = ['l.is_active = TRUE'];
+
+  if (cities) {
+    params.push(cities);
+    conditions.push(`(l.city = ANY($${params.length}) OR c.city = ANY($${params.length}))`);
+  }
+  if (budget) {
+    params.push(budget.min);
+    conditions.push(`l.asking_price >= $${params.length}`);
+    params.push(budget.max);
+    conditions.push(`l.asking_price <= $${params.length}`);
+  }
+
+  const sql = `
+    SELECT
+      l.id          AS listing_id,
+      l.complex_id,
+      l.address,
+      l.city,
+      l.rooms,
+      l.asking_price,
+      l.area_sqm,
+      l.price_per_sqm,
+      l.ssi_score   AS listing_ssi,
+      c.name        AS complex_name,
+      c.city        AS complex_city,
+      c.iai_score,
+      c.enhanced_ssi_score,
+      c.plan_stage,
+      c.has_negative_news,
+      c.accurate_price_sqm,
+      c.city_avg_price_sqm,
+      CASE
+        WHEN c.accurate_price_sqm > 0 AND c.city_avg_price_sqm > 0
+        THEN ROUND(((c.city_avg_price_sqm - c.accurate_price_sqm)::numeric / c.city_avg_price_sqm) * 100, 1)
+        ELSE NULL
+      END AS entry_discount_pct
+    FROM listings l
+    LEFT JOIN complexes c ON c.id = l.complex_id
+    WHERE ${conditions.join(' AND ')}
+    ORDER BY COALESCE(c.iai_score, 0) DESC NULLS LAST,
+             COALESCE(c.enhanced_ssi_score, 0) DESC NULLS LAST
+    LIMIT 200
+  `;
+
+  const candRes = await pool.query(sql, params);
+  const candidates = candRes.rows;
+
+  // Score, filter, sort.
+  const scored = candidates
+    .map(c => ({ c, ...scoreCandidate(c, fd) }))
+    .filter(x => x.score >= MIN_SCORE_TO_PERSIST)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, TOP_N_PER_LEAD);
+
+  // Upsert into lead_matches.
+  let persisted = 0;
+  for (const x of scored) {
+    try {
+      await pool.query(`
+        INSERT INTO lead_matches (lead_id, listing_id, complex_id, match_score, match_reasons, operator_status, updated_at)
+        VALUES ($1, $2, $3, $4, $5::jsonb, 'pending', NOW())
+        ON CONFLICT (lead_id, listing_id) DO UPDATE SET
+          match_score   = EXCLUDED.match_score,
+          match_reasons = EXCLUDED.match_reasons,
+          updated_at    = NOW()
+      `, [leadId, x.c.listing_id, x.c.complex_id, x.score, JSON.stringify(x.reasons)]);
+      persisted++;
+    } catch (e) {
+      logger.warn('[matchEngine] upsert failed', { lead_id: leadId, listing_id: x.c.listing_id, error: e.message });
+    }
+  }
+
+  logger.info('[matchEngine] match complete', {
+    lead_id: leadId,
+    candidates_scanned: candidates.length,
+    matches_persisted: persisted,
+    top_score: scored[0]?.score ?? null
+  });
+
+  return {
+    lead_id: leadId,
+    user_type: lead.user_type,
+    candidates_scanned: candidates.length,
+    matches_persisted: persisted,
+    top_score: scored[0]?.score ?? null,
+    top_match_reasons: scored[0]?.reasons ?? []
+  };
+}
+
+/**
+ * Read top-N matches for a lead (for the operator's Match tab UI).
+ */
+async function getMatchesForLead(leadId, limit = 10) {
+  const r = await pool.query(`
+    SELECT
+      lm.id, lm.match_score, lm.match_reasons, lm.operator_status,
+      lm.created_at, lm.updated_at,
+      l.id AS listing_id, l.title, l.address, l.city, l.rooms, l.asking_price,
+      l.area_sqm, l.price_per_sqm, l.url, l.phone, l.contact_name,
+      l.thumbnail_url, l.source, l.first_seen,
+      c.id AS complex_id, c.name AS complex_name, c.iai_score,
+      c.enhanced_ssi_score, c.plan_stage, c.developer
+    FROM lead_matches lm
+    LEFT JOIN listings  l ON l.id = lm.listing_id
+    LEFT JOIN complexes c ON c.id = lm.complex_id
+    WHERE lm.lead_id = $1
+    ORDER BY lm.match_score DESC, lm.created_at DESC
+    LIMIT $2
+  `, [leadId, Math.min(parseInt(limit) || 10, 50)]);
+  return r.rows;
+}
+
+/**
+ * Update operator_status on a single match (pending/contacted/sent/dismissed/won/lost).
+ */
+async function updateMatchStatus(matchId, status, notes) {
+  const valid = ['pending', 'contacted', 'sent', 'dismissed', 'won', 'lost'];
+  if (!valid.includes(status)) {
+    throw new Error(`invalid status; must be one of ${valid.join(', ')}`);
+  }
+  const r = await pool.query(`
+    UPDATE lead_matches
+    SET operator_status = $1, notes = COALESCE($2, notes), updated_at = NOW()
+    WHERE id = $3
+    RETURNING id, lead_id, listing_id, operator_status, notes, updated_at
+  `, [status, notes ?? null, matchId]);
+  return r.rows[0];
+}
+
+module.exports = {
+  matchLead,
+  getMatchesForLead,
+  updateMatchStatus,
+  AREA_TO_CITIES,
+  BUDGET_RANGES
+};


### PR DESCRIPTION
Match Engine v1. Closes the missing revenue plumbing: investor lead arrives via u-r-quantum.com Supabase webhook, lands in website_leads, gets scored against listings, top matches written to a new lead_matches table, operator works the matches in the dashboard.

## Changes

1. New migration src/db/migrations/020_lead_matches.sql. Creates lead_matches table with FK to website_leads, listings, complexes. UNIQUE(lead_id, listing_id) for idempotent upsert. Indexes on (lead_id, match_score DESC), operator_status, complex_id, created_at. Idempotent (CREATE IF NOT EXISTS).
2. New src/services/matchEngine.js. matchLead(leadId) reads form_data (budget, areas), expands area codes to Hebrew city lists, queries listings JOIN complexes filtered by city + budget, scores candidates (base 50 plus IAI, SSI, entry-discount, penalize construction stage and negative news), upserts top-20 with score above 40 into lead_matches. Plus getMatchesForLead and updateMatchStatus helpers.
3. New src/routes/leadIngestRoutes.js with 4 endpoints, mounted at /api.
   - POST /api/leads-ingest: Supabase webhook entry. Requires X-Webhook-Secret header equal to env SUPABASE_WEBHOOK_SECRET (fail closed if env unset). Idempotent on (email, phone). Responds 202 then runs matchLead in background.
   - POST /api/leads/:id/match: operator-triggered re-match.
   - GET  /api/leads/:id/matches: read top-N matches.
   - PATCH /api/lead-matches/:id: update operator_status.
4. src/index.js: register migration 020 in start(), mount leadIngestRoutes at /api inside quantumRoutes, add X-Webhook-Secret to CORS allowedHeaders, exclude /api/leads-ingest from rate limit.

## Required env var

SUPABASE_WEBHOOK_SECRET must be set in Railway. If unset, /api/leads-ingest returns 503 (no leads will be ingested). The other 3 endpoints work without it.

The matching Supabase Edge Function on the u-r-quantum side (separate repo/Lovable) needs the same secret in its env and must POST with header X-Webhook-Secret.

## Risk assessment

| Change | Severity | Notes |
|--------|----------|-------|
| New table lead_matches | low | CREATE IF NOT EXISTS, no alter to existing tables. FK with ON DELETE CASCADE/SET NULL is correct. |
| Migration runs every boot | low | Idempotent. Adds a few ms. |
| New POST /api/leads-ingest (no rate limit) | medium | Excluded from rate limit so legitimate Supabase webhook bursts pass. Secret-gated, fail closed if env missing. If secret leaks, attacker can flood website_leads without rate limit until secret rotated. |
| New POST /api/leads/:id/match (no auth) | medium | Anyone can trigger expensive match query for any lead id. Burns DB but writes only to lead_matches, no PII modified. Same auth model as existing /api/leads, /api/scan etc. (none). Should be hardened when global auth lands. |
| New GET /api/leads/:id/matches (no auth) | low | Read-only. Returns listing addresses, prices, IAI/SSI scores. No lead PII (name/phone/email NOT included). Same auth posture as /api/leads itself. |
| New PATCH /api/lead-matches/:id (no auth) | medium | Anyone can flip operator_status. Same caveat as above. |
| AREA_TO_CITIES hardcoded coverage | low | Covers 6 region codes (center / sharon / north / south / jerusalem / haifa) with the largest Hebrew city names. Listings in cities outside the list (e.g., יבנה) won't surface for area-filtered investor leads. Pure expand-when-needed, no breakage. |
| MIN_SCORE_TO_PERSIST = 40 | low | Hardcoded threshold; matches scoring under 40 not saved. With sparse data some leads may show zero matches even though weak candidates exist. Tunable. |
| match runs in setImmediate after webhook 202 | low | If match throws, lead is saved but no matches persisted. Logged. Operator can re-run via POST /leads/:id/match. |
| CORS allowedHeaders adds X-Webhook-Secret | low | Additive. Required so browser preflight doesn't block the webhook header (although Supabase Edge Function won't trigger preflight). |
| Existing routes / handlers / response shapes | none | Untouched. Pure additive PR. |

## Smoke test after merge

After Railway auto-deploy, expected:
- /api/_routes shows leadIngestRoutes loaded
- POST /api/leads-ingest without header returns 401 (or 503 if secret unset)
- POST /api/leads-ingest with header returns 202 and starts background match
- GET /api/leads/1/matches returns either matches array or [] for an investor lead
- pg query "select count(*) from lead_matches" succeeds (table exists)

## Roadmap

Day 4-5 of 7. Next: Day 6 Map view via Leaflet on Complexes + Listings.