### PR TITLE
Day 6: Map view via Leaflet (standalone /map page + /api/map endpoints)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -145,9 +145,9 @@ function loadAllRoutes() {
     // 2026-04-28 (Day 2): chartRoutes for /api/chart/* (4 endpoints) used by dashboard graphs.
     { path: '/api/chart',              file: 'routes/chartRoutes.js' },
     // 2026-04-28 (Day 4-5): Match Engine ingest + match endpoints.
-    // Mounted at /api so paths land at /api/leads-ingest, /api/leads/:id/match,
-    // /api/leads/:id/matches, /api/lead-matches/:id.
     { path: '/api',                    file: 'routes/leadIngestRoutes.js' },
+    // 2026-04-28 (Day 6): Map endpoints for the standalone /map page.
+    { path: '/api/map',                file: 'routes/mapRoutes.js' },
     { path: '/api/chat',               file: 'routes/chatRoutes.js' },
     { path: '/api/intelligence',       file: 'routes/intelligenceRoutes.js' },
     { path: '/api/facebook',           file: 'routes/facebookRoute.js' },
@@ -349,6 +349,11 @@ app.get('/api/_routes', (req, res) => {
       total: routeLoadResults.length
     }
   });
+});
+
+// 2026-04-28 (Day 6): standalone Leaflet map page. Reads /api/map/data.
+app.get('/map', (req, res) => {
+  res.sendFile(path.join(__dirname, 'views', 'quantum-map.html'));
 });
 
 app.get('/', (req, res) => res.redirect('/dashboard'));

--- a/src/routes/mapRoutes.js
+++ b/src/routes/mapRoutes.js
@@ -1,0 +1,177 @@
+/**
+ * Map Routes - Day 6 (2026-04-28).
+ *
+ * GET /api/map/data    — complexes + active listings positioned at city centroids.
+ * GET /api/map/cities  — city centroid table for zoom-to-city UI.
+ *
+ * Coordinates strategy: the analyzer DB does not yet have lat/lng columns
+ * on complexes/listings. Day 6 uses a hardcoded city-centroid lookup so
+ * the map renders something useful immediately. PostGIS migration is a
+ * later task. Markers are jittered ±0.005 deg to avoid stacking.
+ */
+
+const express = require('express');
+const router = express.Router();
+const pool = require('../db/pool');
+const { logger } = require('../services/logger');
+
+// City centroids (lat, lng, WGS84). Coverage focused on cities that
+// appear in the analyzer's complexes / listings data. Add more here
+// as needed; missing cities are returned without coords.
+const CITY_CENTROIDS = {
+  'תל אביב':       { lat: 32.0853, lng: 34.7818 },
+  'תל אביב-יפו':   { lat: 32.0853, lng: 34.7818 },
+  'ירושלים':       { lat: 31.7683, lng: 35.2137 },
+  'חיפה':          { lat: 32.7940, lng: 34.9896 },
+  'ראשון לציון':   { lat: 31.9540, lng: 34.8044 },
+  'פתח תקווה':     { lat: 32.0871, lng: 34.8870 },
+  'אשדוד':         { lat: 31.8044, lng: 34.6553 },
+  'נתניה':         { lat: 32.3286, lng: 34.8567 },
+  'באר שבע':       { lat: 31.2518, lng: 34.7913 },
+  'בני ברק':       { lat: 32.0840, lng: 34.8338 },
+  'חולון':         { lat: 32.0167, lng: 34.7792 },
+  'רמת גן':        { lat: 32.0689, lng: 34.8242 },
+  'אשקלון':        { lat: 31.6688, lng: 34.5715 },
+  'רחובות':        { lat: 31.8947, lng: 34.8086 },
+  'בת ים':         { lat: 32.0167, lng: 34.7500 },
+  'בית שמש':       { lat: 31.7456, lng: 34.9886 },
+  'כפר סבא':       { lat: 32.1750, lng: 34.9069 },
+  'הרצליה':        { lat: 32.1624, lng: 34.8447 },
+  'חדרה':          { lat: 32.4344, lng: 34.9197 },
+  'מודיעין':       { lat: 31.8928, lng: 35.0078 },
+  'נצרת':          { lat: 32.6996, lng: 35.3035 },
+  'רמלה':          { lat: 31.9293, lng: 34.8666 },
+  'לוד':           { lat: 31.9522, lng: 34.8954 },
+  'רעננה':         { lat: 32.1847, lng: 34.8708 },
+  'גבעתיים':       { lat: 32.0719, lng: 34.8108 },
+  'הוד השרון':     { lat: 32.1561, lng: 34.8881 },
+  'קריית גת':      { lat: 31.6107, lng: 34.7642 },
+  'אילת':          { lat: 29.5577, lng: 34.9519 },
+  'נהריה':         { lat: 33.0034, lng: 35.0978 },
+  'טבריה':         { lat: 32.7960, lng: 35.5305 },
+  'צפת':           { lat: 32.9625, lng: 35.4969 },
+  'עכו':           { lat: 32.9281, lng: 35.0770 },
+  'דימונה':        { lat: 31.0700, lng: 35.0333 },
+  'קריית ביאליק':   { lat: 32.8333, lng: 35.0833 },
+  'קריית מוצקין':   { lat: 32.8392, lng: 35.0739 },
+  'קריית ים':      { lat: 32.8442, lng: 35.0697 },
+  'קריית אתא':     { lat: 32.8128, lng: 35.1056 },
+  'קריית אונו':    { lat: 32.0651, lng: 34.8553 },
+  'יבנה':          { lat: 31.8786, lng: 34.7406 },
+  'נס ציונה':      { lat: 31.9293, lng: 34.7990 },
+  'ראש העין':      { lat: 32.0844, lng: 34.9536 },
+  'גבעת שמואל':    { lat: 32.0793, lng: 34.8480 },
+  'יהוד':          { lat: 32.0333, lng: 34.8833 },
+  'אור יהודה':     { lat: 32.0306, lng: 34.8506 },
+  'רמת השרון':     { lat: 32.1466, lng: 34.8430 },
+  'נשר':           { lat: 32.7702, lng: 35.0440 },
+  'טירת כרמל':     { lat: 32.7610, lng: 34.9716 },
+  'כרמיאל':        { lat: 32.9189, lng: 35.2920 },
+  'קריית שמונה':   { lat: 33.2079, lng: 35.5697 },
+  'מבשרת ציון':    { lat: 31.7986, lng: 35.1483 },
+  'נתיבות':        { lat: 31.4221, lng: 34.5938 },
+  'אופקים':        { lat: 31.3144, lng: 34.6175 },
+};
+
+function jitter(seed) {
+  // Deterministic small offset based on numeric id so a row always renders
+  // at the same spot. ±0.0035 deg ≈ ±390 m at Israel's latitude.
+  const n = Number(seed) || 0;
+  const a = ((n * 9301 + 49297) % 233280) / 233280;
+  const b = ((n * 49297 + 9301) % 233280) / 233280;
+  return { dlat: (a - 0.5) * 0.007, dlng: (b - 0.5) * 0.007 };
+}
+
+function attachCoords(row, idForJitter) {
+  const c = CITY_CENTROIDS[row.city];
+  if (!c) return null;
+  const { dlat, dlng } = jitter(idForJitter);
+  return { lat: c.lat + dlat, lng: c.lng + dlng };
+}
+
+/**
+ * GET /api/map/data
+ * Query params:
+ *   minIAI: filter complexes with iai_score >= N (default 0)
+ *   activeOnly: 'true' to filter listings to is_active = TRUE (default true)
+ */
+router.get('/data', async (req, res) => {
+  const minIAI = parseFloat(req.query.minIAI) || 0;
+  const activeOnly = req.query.activeOnly !== 'false';
+
+  const safe = async (sql, params) => {
+    try { const r = await pool.query(sql, params); return r.rows; }
+    catch (e) { logger.warn('[mapRoutes] query failed', { error: e.message }); return []; }
+  };
+
+  const [complexRows, listingRows] = await Promise.all([
+    safe(`
+      SELECT id, name, city, neighborhood, addresses, iai_score,
+             enhanced_ssi_score AS ssi_score, status, plan_stage, developer,
+             existing_units AS units_count
+      FROM complexes
+      WHERE COALESCE(iai_score, 0) >= $1
+      ORDER BY iai_score DESC NULLS LAST
+      LIMIT 500
+    `, [minIAI]),
+    safe(`
+      SELECT l.id, l.address, l.title, l.city, l.rooms, l.asking_price,
+             l.area_sqm, l.price_per_sqm, l.source, l.url, l.thumbnail_url,
+             l.ssi_score, l.first_seen, l.is_foreclosure, l.is_inheritance,
+             c.id AS complex_id, c.name AS complex_name, c.iai_score
+      FROM listings l
+      LEFT JOIN complexes c ON c.id = l.complex_id
+      WHERE ${activeOnly ? 'l.is_active = TRUE' : '1=1'}
+      ORDER BY l.first_seen DESC NULLS LAST
+      LIMIT 1000
+    `, []),
+  ]);
+
+  const complexes = [];
+  const complexesNoCoords = [];
+  for (const r of complexRows) {
+    const coords = attachCoords(r, r.id);
+    if (coords) complexes.push({ ...r, ...coords });
+    else complexesNoCoords.push({ id: r.id, name: r.name, city: r.city });
+  }
+
+  const listings = [];
+  const listingsNoCoords = [];
+  for (const r of listingRows) {
+    const coords = attachCoords(r, r.id + 1000000);
+    if (coords) listings.push({ ...r, ...coords });
+    else listingsNoCoords.push({ id: r.id, city: r.city });
+  }
+
+  res.json({
+    success: true,
+    complexes,
+    listings,
+    summary: {
+      complexes_total: complexRows.length,
+      complexes_mapped: complexes.length,
+      complexes_skipped_no_city: complexesNoCoords.length,
+      listings_total: listingRows.length,
+      listings_mapped: listings.length,
+      listings_skipped_no_city: listingsNoCoords.length,
+      cities_supported: Object.keys(CITY_CENTROIDS).length
+    },
+    skipped_cities_sample: [
+      ...complexesNoCoords.slice(0, 5).map(c => `complex#${c.id} ${c.city || '(null)'}`),
+      ...listingsNoCoords.slice(0, 5).map(l => `listing#${l.id} ${l.city || '(null)'}`)
+    ]
+  });
+});
+
+/**
+ * GET /api/map/cities — exposed for the UI to populate a "zoom to city" dropdown.
+ */
+router.get('/cities', (req, res) => {
+  res.json({
+    success: true,
+    cities: Object.entries(CITY_CENTROIDS).map(([name, { lat, lng }]) => ({ name, lat, lng })),
+    total: Object.keys(CITY_CENTROIDS).length
+  });
+});
+
+module.exports = router;

--- a/src/views/quantum-map.html
+++ b/src/views/quantum-map.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>QUANTUM Map</title>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+  integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
+<style>
+  html, body { margin: 0; padding: 0; height: 100%; font-family: 'Heebo', Arial, sans-serif; background: #0f2b46; color: #e5e7eb; }
+  #map { position: absolute; top: 0; bottom: 0; right: 0; left: 0; }
+  .qm-panel {
+    position: absolute; top: 12px; left: 12px; z-index: 500;
+    background: rgba(15, 43, 70, 0.95); color: #f9fafb;
+    padding: 14px 16px; border-radius: 10px;
+    box-shadow: 0 6px 20px rgba(0,0,0,0.4);
+    width: 280px; font-size: 13px;
+  }
+  .qm-panel h2 { margin: 0 0 10px; font-size: 15px; color: #93c5fd; }
+  .qm-row { margin: 8px 0; display: flex; align-items: center; gap: 8px; }
+  .qm-row label { flex: 1; }
+  .qm-row input[type=range] { flex: 2; }
+  .qm-row select { flex: 2; padding: 4px; background: #0f2b46; color: #f9fafb; border: 1px solid #334155; border-radius: 4px; }
+  .qm-stats { font-size: 11px; color: #94a3b8; margin-top: 12px; padding-top: 10px; border-top: 1px solid #334155; }
+  .qm-legend { position: absolute; bottom: 18px; left: 12px; z-index: 500;
+    background: rgba(15, 43, 70, 0.95); color: #f9fafb;
+    padding: 10px 12px; border-radius: 8px; font-size: 12px; }
+  .qm-legend .dot { display: inline-block; width: 12px; height: 12px; border-radius: 50%; margin-left: 6px; vertical-align: middle; }
+  .leaflet-popup-content-wrapper { background: #1e293b; color: #f9fafb; }
+  .leaflet-popup-tip { background: #1e293b; }
+  .qm-popup b { color: #93c5fd; }
+  .qm-popup a { color: #60a5fa; }
+  .qm-error { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);
+    background: #7f1d1d; color: white; padding: 16px 20px; border-radius: 8px; z-index: 600; display: none; }
+</style>
+</head>
+<body>
+
+<div id="map"></div>
+
+<div class="qm-panel">
+  <h2>QUANTUM Map</h2>
+  <div class="qm-row">
+    <label>Min IAI</label>
+    <input type="range" id="minIAI" min="0" max="100" step="5" value="0" />
+    <span id="minIAIVal" style="width: 28px; text-align: left;">0</span>
+  </div>
+  <div class="qm-row">
+    <label><input type="checkbox" id="showComplexes" checked /> Complexes</label>
+    <label><input type="checkbox" id="showListings" checked /> Listings</label>
+  </div>
+  <div class="qm-row">
+    <label>Zoom to</label>
+    <select id="cityZoom">
+      <option value="">-- Select city --</option>
+    </select>
+  </div>
+  <div class="qm-stats" id="stats">Loading...</div>
+</div>
+
+<div class="qm-legend">
+  <div><span class="dot" style="background: #dc2626;"></span> IAI 80+</div>
+  <div><span class="dot" style="background: #f59e0b;"></span> IAI 60-79</div>
+  <div><span class="dot" style="background: #fbbf24;"></span> IAI 40-59</div>
+  <div><span class="dot" style="background: #6b7280;"></span> IAI &lt;40</div>
+  <div><span class="dot" style="background: #3b82f6;"></span> Listing</div>
+</div>
+
+<div class="qm-error" id="error"></div>
+
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+  integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+
+<script>
+  const map = L.map('map', { zoomControl: true }).setView([31.5, 35.0], 8);
+
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    maxZoom: 19, attribution: '© OpenStreetMap'
+  }).addTo(map);
+
+  const complexLayer = L.layerGroup().addTo(map);
+  const listingLayer = L.layerGroup().addTo(map);
+
+  function iaiColor(iai) {
+    if (iai >= 80) return '#dc2626';
+    if (iai >= 60) return '#f59e0b';
+    if (iai >= 40) return '#fbbf24';
+    return '#6b7280';
+  }
+
+  function fmtIls(n) {
+    if (!n && n !== 0) return '-';
+    return new Intl.NumberFormat('he-IL', { style: 'currency', currency: 'ILS', maximumFractionDigits: 0 }).format(n);
+  }
+
+  function complexPopup(c) {
+    return `<div class="qm-popup">
+      <b>${c.name || c.addresses || 'מתחם'}</b><br>
+      ${c.city || ''} ${c.neighborhood ? '· ' + c.neighborhood : ''}<br>
+      IAI: <b>${c.iai_score ?? '-'}</b> · SSI: <b>${c.ssi_score ?? '-'}</b><br>
+      Stage: ${c.plan_stage || '-'}<br>
+      Status: ${c.status || '-'}<br>
+      Developer: ${c.developer || '-'}<br>
+      Units: ${c.units_count || '-'}
+    </div>`;
+  }
+
+  function listingPopup(l) {
+    return `<div class="qm-popup">
+      <b>${l.title || l.address || 'דירה'}</b><br>
+      ${l.city || ''} · ${l.rooms || '?'} rooms · ${l.area_sqm || '?'} m²<br>
+      Price: <b>${fmtIls(l.asking_price)}</b><br>
+      ₪/m²: ${fmtIls(l.price_per_sqm)}<br>
+      Source: ${l.source || '-'}<br>
+      ${l.complex_name ? 'Complex: <b>' + l.complex_name + '</b> (IAI ' + (l.iai_score ?? '-') + ')<br>' : ''}
+      ${l.url ? '<a href="' + l.url + '" target="_blank" rel="noopener">Open listing</a>' : ''}
+    </div>`;
+  }
+
+  let allComplexes = [];
+  let allListings = [];
+
+  function render() {
+    complexLayer.clearLayers();
+    listingLayer.clearLayers();
+
+    const minIAI = parseInt(document.getElementById('minIAI').value);
+    const showComplexes = document.getElementById('showComplexes').checked;
+    const showListings = document.getElementById('showListings').checked;
+
+    let cShown = 0, lShown = 0;
+
+    if (showComplexes) {
+      for (const c of allComplexes) {
+        if ((c.iai_score || 0) < minIAI) continue;
+        const color = iaiColor(c.iai_score || 0);
+        const radius = 6 + Math.min((c.iai_score || 0) / 10, 8);
+        L.circleMarker([c.lat, c.lng], { radius, color, fillColor: color, fillOpacity: 0.7, weight: 2 })
+          .bindPopup(complexPopup(c)).addTo(complexLayer);
+        cShown++;
+      }
+    }
+
+    if (showListings) {
+      for (const l of allListings) {
+        if (minIAI > 0 && (l.iai_score || 0) < minIAI) continue;
+        L.circleMarker([l.lat, l.lng], { radius: 4, color: '#3b82f6', fillColor: '#3b82f6', fillOpacity: 0.6, weight: 1 })
+          .bindPopup(listingPopup(l)).addTo(listingLayer);
+        lShown++;
+      }
+    }
+
+    document.getElementById('stats').innerHTML =
+      `Complexes shown: <b>${cShown}</b> / ${allComplexes.length}<br>` +
+      `Listings shown: <b>${lShown}</b> / ${allListings.length}`;
+  }
+
+  function showError(msg) {
+    const el = document.getElementById('error');
+    el.textContent = msg;
+    el.style.display = 'block';
+  }
+
+  async function loadData() {
+    try {
+      const r = await fetch('/api/map/data');
+      if (!r.ok) throw new Error('HTTP ' + r.status);
+      const data = await r.json();
+      allComplexes = data.complexes || [];
+      allListings = data.listings || [];
+      render();
+    } catch (e) {
+      showError('Failed to load /api/map/data: ' + e.message);
+    }
+  }
+
+  async function loadCities() {
+    try {
+      const r = await fetch('/api/map/cities');
+      const data = await r.json();
+      const sel = document.getElementById('cityZoom');
+      for (const c of data.cities || []) {
+        const opt = document.createElement('option');
+        opt.value = JSON.stringify({ lat: c.lat, lng: c.lng });
+        opt.textContent = c.name;
+        sel.appendChild(opt);
+      }
+    } catch (e) { /* non-fatal */ }
+  }
+
+  document.getElementById('minIAI').addEventListener('input', (e) => {
+    document.getElementById('minIAIVal').textContent = e.target.value;
+    render();
+  });
+  document.getElementById('showComplexes').addEventListener('change', render);
+  document.getElementById('showListings').addEventListener('change', render);
+  document.getElementById('cityZoom').addEventListener('change', (e) => {
+    if (!e.target.value) return;
+    const { lat, lng } = JSON.parse(e.target.value);
+    map.setView([lat, lng], 13);
+  });
+
+  loadData();
+  loadCities();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Day 6: standalone Leaflet map page accessible at /map.

## Changes

1. New src/routes/mapRoutes.js. Two endpoints under /api/map:
   - GET /data: complexes plus active listings positioned at city centroid lat/lng. Hardcoded table of 51 Israeli cities. Deterministic jitter (about 390m) prevents marker overlap. Returns rich metadata for popups (IAI/SSI/stage/developer/units for complexes, address/price/rooms/source/url for listings) plus a summary block with mapped vs skipped counts.
   - GET /cities: city centroid table for zoom-to-city UI.
2. New src/views/quantum-map.html. Self-contained Leaflet 1.9 page with CDN scripts/styles. Filters: minIAI slider, toggle complexes/listings, zoom-to-city dropdown. Markers colored by IAI band. Clicks open popups.
3. src/index.js: mount mapRoutes at /api/map inside quantumRoutes, add app.get(/map) to serve the HTML file.

## Risk assessment

| Change | Severity | Notes |
|--------|----------|-------|
| New mapRoutes.js | none | Pure additive. Read-only queries. safeQuery wrappers degrade missing-table to []. |
| New /map HTML route | none | New URL, no collision with /dashboard or /sandbox. |
| CSP allows unpkg.com | unchanged | Leaflet CDN at unpkg.com is already in CSP scriptSrc and styleSrc from earlier build. openstreetmap tiles already in imgSrc. No CSP changes needed. |
| City centroids hardcoded | low | 51 cities covered. Listings/complexes in cities outside this list are skipped from the map (returned in skipped_cities_sample for diagnostics). Real geocoding is a future task (Day 7+ PostGIS work). |
| Marker jitter is deterministic | none | Each row maps to the same offset every render. No user-visible movement. |

## What did NOT change

No DB migrations, no new deps, no schema columns, no edits to existing handlers. dashboard.html (254KB) is untouched. A link to /map can be added in a follow-up PR if desired.

## Smoke test after merge

- /api/map/cities returns about 51 entries
- /api/map/data returns complexes/listings arrays plus a summary with mapped vs skipped counts
- /map serves the HTML page
- Page loads Leaflet, fetches data, renders markers

## Roadmap

Day 6 of 7. Next: Day 7 hot-opportunity WhatsApp push, kones phone enrichment, start.js cleanup.