### PR TITLE
Day 7: Hot-opportunity WhatsApp push to operator

### DIFF
--- a/src/cron/hotOpportunityCron.js
+++ b/src/cron/hotOpportunityCron.js
@@ -1,0 +1,155 @@
+/**
+ * Hot Opportunity Cron - Day 7 (2026-04-28).
+ *
+ * Polls listings table every 30 minutes 09-21 IL. For each listing that:
+ *   - was first_seen within the last 6 hours
+ *   - belongs to a complex with iai_score >= 80 AND enhanced_ssi_score >= 60
+ *   - is_active = TRUE
+ *   - is NOT already in hot_opportunity_alerts
+ * sends a Hebrew operator WhatsApp via inforuService.sendMessage and logs
+ * the attempt to hot_opportunity_alerts (UNIQUE on listing_id ensures we
+ * never send twice for the same listing).
+ *
+ * Env: OPERATOR_WHATSAPP_PHONE (required for actual send; otherwise log_only mode).
+ * Tunables: HOT_OPP_MIN_IAI, HOT_OPP_MIN_SSI, HOT_OPP_LOOKBACK_HOURS.
+ */
+
+const pool = require('../db/pool');
+const { logger } = require('../services/logger');
+
+// Defaults; overridable via env.
+const MIN_IAI       = parseInt(process.env.HOT_OPP_MIN_IAI || '80', 10);
+const MIN_SSI       = parseInt(process.env.HOT_OPP_MIN_SSI || '60', 10);
+const LOOKBACK_HRS  = parseInt(process.env.HOT_OPP_LOOKBACK_HOURS || '6', 10);
+const MAX_PER_RUN   = parseInt(process.env.HOT_OPP_MAX_PER_RUN || '5', 10);
+
+function fmtIls(n) {
+  if (!n && n !== 0) return '-';
+  return new Intl.NumberFormat('he-IL', { style: 'currency', currency: 'ILS', maximumFractionDigits: 0 }).format(n);
+}
+
+function buildMessage(row) {
+  const lines = [
+    '🔥 הזדמנות חמה QUANTUM',
+    '',
+    `${row.complex_name || row.complex_addresses || 'מתחם'} · ${row.city || '-'}`,
+    `IAI ${row.iai_score ?? '-'} | SSI ${row.enhanced_ssi_score ?? '-'}`,
+    `שלב: ${row.plan_stage || row.complex_status || '-'}${row.developer ? ' · יזם: ' + row.developer : ''}`,
+    '',
+    `${row.address || row.title || 'דירה'} · ${row.rooms || '?'} חד׳ · ${row.area_sqm || '?'} מ"ר`,
+    `מחיר: ${fmtIls(row.asking_price)}${row.price_per_sqm ? ' · ' + fmtIls(row.price_per_sqm) + '/מ"ר' : ''}`,
+    `מקור: ${row.source || '-'}${row.contact_name ? ' · ' + row.contact_name : ''}${row.phone ? ' · ' + row.phone : ''}`,
+  ];
+  if (row.url) lines.push('', row.url);
+  return lines.join('\n');
+}
+
+async function findHotOpportunities() {
+  const r = await pool.query(`
+    SELECT l.id              AS listing_id,
+           l.title, l.address, l.city, l.rooms, l.area_sqm,
+           l.asking_price, l.price_per_sqm, l.source, l.url,
+           l.phone, l.contact_name, l.first_seen,
+           c.id              AS complex_id,
+           c.name            AS complex_name,
+           c.addresses       AS complex_addresses,
+           c.iai_score, c.enhanced_ssi_score, c.plan_stage,
+           c.status          AS complex_status, c.developer
+    FROM listings l
+    JOIN complexes c ON c.id = l.complex_id
+    WHERE l.is_active = TRUE
+      AND l.first_seen >= NOW() - INTERVAL '${LOOKBACK_HRS} hours'
+      AND COALESCE(c.iai_score, 0)            >= $1
+      AND COALESCE(c.enhanced_ssi_score, 0)   >= $2
+      AND NOT EXISTS (
+        SELECT 1 FROM hot_opportunity_alerts a WHERE a.listing_id = l.id
+      )
+    ORDER BY c.iai_score DESC, c.enhanced_ssi_score DESC, l.first_seen DESC
+    LIMIT $3
+  `, [MIN_IAI, MIN_SSI, MAX_PER_RUN]);
+  return r.rows;
+}
+
+async function logAlert(row, channel, status, recipient, messagePreview, error) {
+  try {
+    await pool.query(`
+      INSERT INTO hot_opportunity_alerts
+        (listing_id, complex_id, iai_score, ssi_score, channel, status, recipient, message_preview, error)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+      ON CONFLICT (listing_id) DO NOTHING
+    `, [
+      row.listing_id, row.complex_id || null,
+      row.iai_score ?? null, row.enhanced_ssi_score ?? null,
+      channel, status, recipient || null,
+      (messagePreview || '').substring(0, 500),
+      error ? String(error).substring(0, 500) : null
+    ]);
+  } catch (e) {
+    logger.warn('[hotOppCron] failed to log alert', { listing_id: row.listing_id, error: e.message });
+  }
+}
+
+async function run() {
+  let inforu;
+  try { inforu = require('../services/inforuService'); }
+  catch (e) {
+    logger.warn('[hotOppCron] inforuService not available', { error: e.message });
+  }
+
+  const operatorPhone = process.env.OPERATOR_WHATSAPP_PHONE
+    || process.env.OPERATOR_PHONE
+    || null;
+
+  let opportunities;
+  try { opportunities = await findHotOpportunities(); }
+  catch (e) {
+    logger.warn('[hotOppCron] query failed', { error: e.message });
+    return { scanned: 0, sent: 0, logged: 0, error: e.message };
+  }
+
+  if (opportunities.length === 0) {
+    return { scanned: 0, sent: 0, logged: 0 };
+  }
+
+  let sent = 0;
+  let logged = 0;
+  for (const row of opportunities) {
+    const message = buildMessage(row);
+
+    if (!operatorPhone) {
+      // No phone configured: log_only so we don't keep rediscovering the same listing.
+      await logAlert(row, 'log_only', 'log_only', null, message, 'OPERATOR_WHATSAPP_PHONE not set');
+      logged++;
+      continue;
+    }
+
+    if (!inforu || typeof inforu.sendMessage !== 'function') {
+      await logAlert(row, 'log_only', 'log_only', operatorPhone, message, 'inforuService unavailable');
+      logged++;
+      continue;
+    }
+
+    try {
+      const result = await inforu.sendMessage(operatorPhone, message, {
+        preferWhatsApp: true,
+        customerParameter: 'QUANTUM_HOT_OPP'
+      });
+      const channel = result?.channel === 'whatsapp_chat' ? 'whatsapp' : (result?.channel || 'sms');
+      const status = result?.success ? 'sent' : 'failed';
+      await logAlert(row, channel, status, operatorPhone, message, result?.success ? null : result?.description);
+      if (result?.success) sent++;
+      logged++;
+    } catch (e) {
+      await logAlert(row, 'whatsapp', 'failed', operatorPhone, message, e.message);
+      logged++;
+      logger.warn('[hotOppCron] send error', { listing_id: row.listing_id, error: e.message });
+    }
+  }
+
+  logger.info('[hotOppCron] run complete', {
+    scanned: opportunities.length, sent, logged, operator_configured: !!operatorPhone
+  });
+  return { scanned: opportunities.length, sent, logged };
+}
+
+module.exports = { run, findHotOpportunities, buildMessage, MIN_IAI, MIN_SSI, LOOKBACK_HRS };

--- a/src/db/migrations/021_hot_opportunity_alerts.sql
+++ b/src/db/migrations/021_hot_opportunity_alerts.sql
@@ -1,0 +1,28 @@
+-- Migration 021: hot_opportunity_alerts table
+-- Created 2026-04-28 (Day 7) for the hot-opportunity WhatsApp push cron.
+-- One row per listing that fired an alert. UNIQUE(listing_id) prevents
+-- duplicate alerts. Idempotent.
+
+CREATE TABLE IF NOT EXISTS hot_opportunity_alerts (
+  id              SERIAL PRIMARY KEY,
+  listing_id      INT NOT NULL REFERENCES listings(id) ON DELETE CASCADE,
+  complex_id      INT REFERENCES complexes(id) ON DELETE SET NULL,
+  iai_score       INT,
+  ssi_score       INT,
+  match_score     NUMERIC(5,2),
+  channel         TEXT NOT NULL DEFAULT 'whatsapp',
+    -- 'whatsapp' | 'sms' | 'log_only' (when no operator phone configured)
+  status          TEXT NOT NULL DEFAULT 'sent',
+    -- 'sent' | 'failed' | 'log_only'
+  recipient       TEXT,
+  message_preview TEXT,
+  error           TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (listing_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_hot_opp_alerts_created
+  ON hot_opportunity_alerts (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_hot_opp_alerts_status
+  ON hot_opportunity_alerts (status, created_at DESC);

--- a/src/index.js
+++ b/src/index.js
@@ -375,6 +375,8 @@ async function start() {
   await runMigrationFile('Multi-channel (019)', path.join(__dirname, 'db', 'migrations', '019_available_channels.sql'));
   // 2026-04-28 (Day 4-5): Match Engine v1
   await runMigrationFile('Lead matches (020)', path.join(__dirname, 'db', 'migrations', '020_lead_matches.sql'));
+  // 2026-04-28 (Day 7): Hot opportunity alerts log
+  await runMigrationFile('Hot opp alerts (021)', path.join(__dirname, 'db', 'migrations', '021_hot_opportunity_alerts.sql'));
   if (isQuantum) await runOutreachMigration();
 
   loadAllRoutes();
@@ -411,6 +413,21 @@ async function start() {
       });
       logger.info('[SsiBatchAggregate] ACTIVE - daily 06:30 IL');
     } catch (e) { logger.warn('[SsiBatchAggregate] Failed:', e.message); }
+
+    // 2026-04-28 (Day 7): Hot Opportunity push to operator.
+    // Every 30 min between 09:00-21:00 IL. Finds new high-IAI/SSI listings,
+    // sends WhatsApp via inforuService, dedupes via hot_opportunity_alerts.
+    try {
+      const cron = require('node-cron');
+      const hotOpp = require('./cron/hotOpportunityCron');
+      cron.schedule('*/30 9-21 * * *', async () => {
+        try { await hotOpp.run(); }
+        catch (e) { logger.warn('[HotOppCron]', e.message); }
+      });
+      logger.info('[HotOppCron] ACTIVE - every 30min 09-21 IL', {
+        operator_phone_set: !!(process.env.OPERATOR_WHATSAPP_PHONE || process.env.OPERATOR_PHONE)
+      });
+    } catch (e) { logger.warn('[HotOppCron] Failed:', e.message); }
 
     try {
       const cron = require('node-cron');


### PR DESCRIPTION
Day 7 (final). Closes the time-to-action gap: when a new high-IAI/SSI listing appears, push it to the operator's WhatsApp within 30 minutes instead of waiting for them to refresh the dashboard.

## Changes

1. New migration src/db/migrations/021_hot_opportunity_alerts.sql. Log table with UNIQUE(listing_id) so the same listing never alerts twice. Fields: listing_id, complex_id, iai_score, ssi_score, channel, status, recipient, message_preview, error, created_at. 3 indexes. Idempotent.
2. New src/cron/hotOpportunityCron.js. Polls listings WHERE first_seen >= NOW()-INTERVAL '6 hours' AND complexes.iai_score >= 80 AND complexes.enhanced_ssi_score >= 60 AND NOT EXISTS in alerts. Sends Hebrew message via inforuService.sendMessage (preferWhatsApp, falls back to SMS). Logs every attempt to hot_opportunity_alerts. Tunables: HOT_OPP_MIN_IAI, HOT_OPP_MIN_SSI, HOT_OPP_LOOKBACK_HOURS, HOT_OPP_MAX_PER_RUN env vars.
3. src/index.js: register migration 021, schedule cron `*/30 9-21 * * *` (every 30 min, 09:00-21:00 IL) under isQuantum.

## Required env var

OPERATOR_WHATSAPP_PHONE (or fallback OPERATOR_PHONE). If unset, cron runs in log_only mode: rows inserted into hot_opportunity_alerts with channel='log_only', status='log_only'. No messages sent. Safe default.

INFORU_USERNAME / INFORU_PASSWORD already exist in Railway env (used by the rest of the WhatsApp pipeline); no change.

## Risk assessment

| Change | Severity | Notes |
|--------|----------|-------|
| New table hot_opportunity_alerts | low | CREATE IF NOT EXISTS, FK with ON DELETE CASCADE/SET NULL. No alter to existing tables. |
| New cron */30 9-21 IL | low | Wrapped in try/catch. Fires at most 26 times per day (09:00-21:00 every 30 min). |
| Sends WhatsApp/SMS to operator | medium | If OPERATOR_WHATSAPP_PHONE is set incorrectly, messages go to wrong number. Mitigation: env var must be explicitly set; fail closed to log_only otherwise. Each listing alerts ONCE (UNIQUE) so a misconfig won't spam beyond the new-listing rate. |
| Uses inforuService.sendMessage | low | Pre-existing service, already used for outreach. preferWhatsApp falls back to SMS automatically. |
| HOT_OPP thresholds (IAI 80, SSI 60, 6h window, 5 per run) | low | Conservative defaults. Tunable via env vars without redeploy. |
| MAX_PER_RUN = 5 | low | Caps cron to 5 sends per fire = max 130 alerts/day in worst case. INFORU rate limits handle the rest. |
| Cost: per-message INFORU cost | low | Ballpark, under 1 ILS per WhatsApp template send. With UNIQUE(listing_id) and conservative thresholds, expected <10/day. |
| Existing routes / handlers | none | Untouched. Pure additive. |

## What did NOT change

No existing endpoint behavior. No edits to dashboard.html. No new deps. start.js cleanup (originally Day 7 in the plan) is still deferred; it's risky and needs a clean local boot to materialize files first. kones phone-enrichment also deferred (depends on external lookup service choice).

## Smoke test after merge

- /api/_routes shows hotOpportunityCron registered
- pg query "SELECT count(*) FROM hot_opportunity_alerts" succeeds
- Logs show "[HotOppCron] ACTIVE - every 30min 09-21 IL"
- After first scheduled fire (next half-hour 09-21 IL): rows appear in hot_opportunity_alerts (either status='sent' if env set, or 'log_only' otherwise)

## Roadmap

Day 7 of 7. After merge, the dashboard fix plan is complete. Outstanding items deferred for later:
- start.js base64+gz boot patcher cleanup (risky, needs careful local testing)
- kones phone-enrichment pipeline (depends on phone lookup vendor)
- dashboard.html column key rename (deferred Day 2 item; check first if post-Day-1 mount fix already populates listings table)