### PR TITLE
Day 8: Surface gaps — hot-opp endpoint, campaign link, drop dead button

### DIFF
--- a/src/cron/bulkOutreachCron.js
+++ b/src/cron/bulkOutreachCron.js
@@ -120,7 +120,7 @@ async function runBulkOutreach() {
 
     const batchSize = Math.min(config.batchSize, remaining);
 
-    // Get unsent listings with phone numbers
+    // Get unsent listings with phone numbers (excluding opted-out phones)
     const { rows: listings } = await pool.query(`
       SELECT l.id, l.address, l.street, l.city, l.phone, l.contact_name,
              l.contact_phone, l.asking_price, l.rooms, l.area_sqm,
@@ -128,10 +128,12 @@ async function runBulkOutreach() {
              c.name as complex_name
       FROM listings l
       LEFT JOIN complexes c ON l.complex_id = c.id
+      LEFT JOIN wa_optouts o ON o.phone = l.phone
       WHERE l.is_active = TRUE
         AND (l.message_status IS NULL OR l.message_status = 'לא נשלחה')
         AND (l.phone IS NOT NULL AND l.phone != '')
         AND l.phone NOT IN ('0000000000', '000-0000000')
+        AND o.id IS NULL
       ORDER BY l.created_at DESC
       LIMIT $1
     `, [batchSize]);

--- a/src/cron/dailyDigestCron.js
+++ b/src/cron/dailyDigestCron.js
@@ -1,0 +1,103 @@
+/**
+ * Daily Operations Digest (Day 8.5).
+ *
+ * Sends a single WhatsApp summary to OPERATOR_WHATSAPP_PHONE every morning
+ * at 08:00 IL: leads/scrapes/messages/hot-opps/matches counts for the past
+ * 24 hours, plus current bot configuration state.
+ *
+ * Why: previously a stalled cron (e.g. bulkOutreachCron disabled) could go
+ * unnoticed for weeks. This is the canary.
+ *
+ * Schedule: 0 8 * * * (registered in src/index.js)
+ */
+
+const pool = require('../db/pool');
+const { logger } = require('../services/logger');
+
+let _running = false;
+
+async function safeCount(sql, params = []) {
+  try {
+    const { rows } = await pool.query(sql, params);
+    return parseInt(rows[0]?.c || 0, 10);
+  } catch (e) {
+    return -1; // sentinel = query failed (table missing etc.)
+  }
+}
+
+async function getSetting(key, defaultValue = '') {
+  try {
+    const { rows } = await pool.query(
+      'SELECT value FROM system_settings WHERE key = $1', [key]
+    );
+    return rows.length > 0 ? rows[0].value : defaultValue;
+  } catch (e) { return defaultValue; }
+}
+
+async function buildDigest() {
+  const since = "NOW() - INTERVAL '24 hours'";
+  const [
+    leadsNew, listingsSeen, messagesSent, hotOpps,
+    matchesNew, optoutsNew,
+  ] = await Promise.all([
+    safeCount(`SELECT COUNT(*) AS c FROM website_leads WHERE created_at > ${since}`),
+    safeCount(`SELECT COUNT(*) AS c FROM listings WHERE first_seen > ${since}`),
+    safeCount(`SELECT COUNT(*) AS c FROM listings WHERE last_message_sent_at > ${since}`),
+    safeCount(`SELECT COUNT(*) AS c FROM hot_opportunity_alerts WHERE created_at > ${since}`),
+    safeCount(`SELECT COUNT(*) AS c FROM lead_matches WHERE created_at > ${since}`),
+    safeCount(`SELECT COUNT(*) AS c FROM wa_optouts WHERE opted_out_at > ${since}`),
+  ]);
+
+  const [bulkEnabled, bulkTemplate, agentPhone] = await Promise.all([
+    getSetting('bulk_outreach_enabled', 'false'),
+    getSetting('bulk_outreach_template_id', ''),
+    getSetting('agent_phone', ''),
+  ]);
+
+  const lines = [
+    'דוח QUANTUM יומי - 24 שעות אחרונות',
+    '',
+    `לידים חדשים: ${leadsNew}`,
+    `דירות חדשות שאותרו: ${listingsSeen}`,
+    `הודעות יוצאות: ${messagesSent}`,
+    `התראות hot-opportunity: ${hotOpps}`,
+    `התאמות חדשות (lead_matches): ${matchesNew}`,
+    `הסרות מרשימת תפוצה: ${optoutsNew}`,
+    '',
+    'מצב בוט מוכרים:',
+    `  enabled=${bulkEnabled} template=${bulkTemplate || '-'} phone=${agentPhone || '-'}`,
+  ];
+
+  return lines.join('\n');
+}
+
+async function runDailyDigest() {
+  if (_running) return { skipped: 'already_running' };
+  _running = true;
+  try {
+    const operatorPhone = process.env.OPERATOR_WHATSAPP_PHONE
+      || process.env.QUANTUM_OPERATOR_PHONE
+      || '';
+    const digest = await buildDigest();
+
+    if (!operatorPhone) {
+      logger.info('[DailyDigest] OPERATOR_WHATSAPP_PHONE not set; logging only');
+      logger.info('[DailyDigest]\n' + digest);
+      return { ok: true, mode: 'log_only', digest };
+    }
+
+    const inforu = require('../services/inforuService');
+    const result = await inforu.sendMessage(operatorPhone, digest, {
+      preferWhatsApp: true, customerParameter: 'QUANTUM_DAILY_DIGEST',
+    });
+    logger.info('[DailyDigest] Sent to operator', { phone: operatorPhone, status: result?.status });
+    return { ok: true, mode: 'sent', digest };
+  } catch (e) {
+    logger.error('[DailyDigest] Failed:', e.message);
+    return { ok: false, error: e.message };
+  } finally {
+    _running = false;
+  }
+}
+
+module.exports = { runDailyDigest, buildDigest };

--- a/src/cron/incomingWhatsAppCron.js
+++ b/src/cron/incomingWhatsAppCron.js
@@ -12,6 +12,7 @@
 
 const inforuService = require('../services/inforuService');
 const botEngine     = require('../services/botEngine');
+const optoutService = require('../services/optoutService');
 const pool          = require('../db/pool');
 const { logger }    = require('../services/logger');
 
@@ -47,6 +48,19 @@ async function pollIncomingWhatsApp() {
       }
 
       try {
+        // Opt-out detection (must run before bot/campaign routing).
+        const optoutKw = optoutService.matchOptoutKeyword(body);
+        if (optoutKw) {
+          await optoutService.recordOptout({
+            phone, source: 'reply_kw', replyText: body, notes: `matched=${optoutKw}`
+          });
+          try {
+            await inforuService.sendWhatsAppChat(phone,
+              'הוסרת מרשימת התפוצה של QUANTUM. לא תקבלו הודעות נוספות. תודה.');
+          } catch (e) { /* best-effort confirmation */ }
+          continue;
+        }
+
         // Find the campaign from existing bot session
         const sess = await pool.query(
           `SELECT zoho_campaign_id FROM bot_sessions

--- a/src/cron/matchAlertCron.js
+++ b/src/cron/matchAlertCron.js
@@ -1,0 +1,102 @@
+/**
+ * Match Alert Cron (Day 8.5).
+ *
+ * Sends an operator WhatsApp alert when a high-score lead_match is created.
+ * Threshold defaults to 80 (configurable via MATCH_ALERT_MIN_SCORE).
+ *
+ * De-duplication: sends only for matches that don't yet have outcome_notes
+ * marked 'alerted' (we co-opt outcome_notes column to track).
+ *
+ * Schedule: registered in src/index.js, every 10 minutes.
+ */
+const pool = require('../db/pool');
+const { logger } = require('../services/logger');
+
+const MIN_SCORE = parseFloat(process.env.MATCH_ALERT_MIN_SCORE || '80');
+const MAX_PER_RUN = parseInt(process.env.MATCH_ALERT_MAX_PER_RUN || '5', 10);
+
+let _running = false;
+
+function fmtIls(n) {
+  if (n == null) return '-';
+  return new Intl.NumberFormat('he-IL', { style: 'currency', currency: 'ILS', maximumFractionDigits: 0 }).format(n);
+}
+
+async function runMatchAlerts() {
+  if (_running) return { skipped: 'already_running' };
+  _running = true;
+
+  try {
+    const { rows: matches } = await pool.query(`
+      SELECT
+        m.id, m.lead_id, m.listing_id, m.score, m.created_at,
+        wl.name AS lead_name, wl.email AS lead_email, wl.phone AS lead_phone,
+        l.address, l.city, l.asking_price, l.url AS listing_url,
+        c.name AS complex_name, c.iai_score, c.enhanced_ssi_score
+      FROM lead_matches m
+      LEFT JOIN website_leads wl ON wl.id = m.lead_id
+      LEFT JOIN listings l ON l.id = m.listing_id
+      LEFT JOIN complexes c ON c.id = l.complex_id
+      WHERE m.score >= $1
+        AND m.created_at > NOW() - INTERVAL '24 hours'
+        AND (m.outcome_notes IS NULL OR m.outcome_notes NOT LIKE '%alerted=1%')
+      ORDER BY m.score DESC
+      LIMIT $2
+    `, [MIN_SCORE, MAX_PER_RUN]);
+
+    if (matches.length === 0) {
+      return { ok: true, sent: 0, reason: 'no_pending' };
+    }
+
+    const operatorPhone = process.env.OPERATOR_WHATSAPP_PHONE
+      || process.env.QUANTUM_OPERATOR_PHONE
+      || '';
+
+    if (!operatorPhone) {
+      logger.info(`[MatchAlert] Found ${matches.length} matches but no OPERATOR_WHATSAPP_PHONE; marking alerted in log_only mode`);
+      for (const m of matches) {
+        await pool.query(
+          `UPDATE lead_matches SET outcome_notes = COALESCE(outcome_notes,'') || ' alerted=1(log_only) ' WHERE id = $1`,
+          [m.id]
+        );
+      }
+      return { ok: true, mode: 'log_only', count: matches.length };
+    }
+
+    const inforu = require('../services/inforuService');
+    let sent = 0;
+
+    for (const m of matches) {
+      const msg = [
+        `התאמה חמה (${Math.round(parseFloat(m.score))})`,
+        '',
+        `ליד: ${m.lead_name || '-'} | ${m.lead_phone || m.lead_email || '-'}`,
+        `דירה: ${m.address || '-'}, ${m.city || '-'} | ${fmtIls(m.asking_price)}`,
+        `מתחם: ${m.complex_name || '-'} (IAI ${m.iai_score || '-'} / SSI ${m.enhanced_ssi_score || '-'})`,
+        m.listing_url ? m.listing_url : '',
+      ].filter(Boolean).join('\n');
+
+      try {
+        await inforu.sendMessage(operatorPhone, msg, {
+          preferWhatsApp: true, customerParameter: 'QUANTUM_MATCH_ALERT',
+        });
+        await pool.query(
+          `UPDATE lead_matches SET outcome_notes = COALESCE(outcome_notes,'') || ' alerted=1 ' WHERE id = $1`,
+          [m.id]
+        );
+        sent++;
+      } catch (e) {
+        logger.warn('[MatchAlert] Send failed for match', { id: m.id, error: e.message });
+      }
+    }
+
+    return { ok: true, mode: 'sent', count: matches.length, sent };
+  } catch (e) {
+    logger.error('[MatchAlert] Run failed:', e.message);
+    return { ok: false, error: e.message };
+  } finally {
+    _running = false;
+  }
+}
+
+module.exports = { runMatchAlerts };

--- a/src/db/migrations/022_optouts_and_match_outcomes.sql
+++ b/src/db/migrations/022_optouts_and_match_outcomes.sql
@@ -1,0 +1,27 @@
+-- Migration 022: opt-out tracking + match outcome columns (Day 8.5)
+--
+-- Why:
+--   * Meta Marketing templates require an opt-out path. We must record opt-outs
+--     and skip those phones in bulkOutreachCron to stay compliant.
+--   * Match Engine needs an outcome field per lead_match for future feedback.
+
+CREATE TABLE IF NOT EXISTS wa_optouts (
+  id            SERIAL PRIMARY KEY,
+  phone         TEXT NOT NULL UNIQUE,
+  opted_out_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  source        TEXT NOT NULL,            -- 'reply_kw' | 'button' | 'manual' | 'api'
+  reply_text    TEXT,
+  listing_id    INT REFERENCES listings(id) ON DELETE SET NULL,
+  notes         TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_wa_optouts_opted_at
+  ON wa_optouts (opted_out_at DESC);
+
+ALTER TABLE lead_matches
+  ADD COLUMN IF NOT EXISTS outcome       TEXT,
+  ADD COLUMN IF NOT EXISTS outcome_at    TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS outcome_notes TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_lead_matches_outcome
+  ON lead_matches (outcome) WHERE outcome IS NOT NULL;

--- a/src/db/migrations/023_listings_unique_index.sql
+++ b/src/db/migrations/023_listings_unique_index.sql
@@ -1,0 +1,35 @@
+-- Migration 023: unique expression index for listings ON CONFLICT (Day 8.5).
+--
+-- Why:
+--   yad2Scraper.js uses
+--     INSERT INTO listings ... ON CONFLICT (source, LOWER(TRIM(address)), LOWER(TRIM(city)))
+--   which requires a UNIQUE INDEX on those exact expressions. Without it
+--   PostgreSQL raises 'no unique or exclusion constraint matching the
+--   ON CONFLICT specification' and the listing is silently dropped.
+--
+-- Idempotency:
+--   - CREATE UNIQUE INDEX IF NOT EXISTS guards re-runs.
+--   - Pre-dedupe step removes existing duplicates that would otherwise
+--     prevent the unique-index creation.
+
+-- Pre-dedupe: keep the lowest id for each (source, LOWER(TRIM(address)), LOWER(TRIM(city))).
+-- We deactivate (not delete) the duplicates to preserve referential integrity.
+WITH dups AS (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (
+      PARTITION BY source, LOWER(TRIM(address)), LOWER(TRIM(city))
+      ORDER BY id
+    ) AS rn
+  FROM listings
+  WHERE address IS NOT NULL AND city IS NOT NULL AND source IS NOT NULL
+)
+UPDATE listings
+SET is_active = FALSE,
+    updated_at = NOW()
+WHERE id IN (SELECT id FROM dups WHERE rn > 1)
+  AND is_active = TRUE;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_listings_source_address_city
+  ON listings (source, LOWER(TRIM(address)), LOWER(TRIM(city)))
+  WHERE address IS NOT NULL AND city IS NOT NULL AND source IS NOT NULL;

--- a/src/index.js
+++ b/src/index.js
@@ -378,6 +378,8 @@ async function start() {
   await runMigrationFile('Lead matches (020)', path.join(__dirname, 'db', 'migrations', '020_lead_matches.sql'));
   // 2026-04-28 (Day 7): Hot opportunity alerts log
   await runMigrationFile('Hot opp alerts (021)', path.join(__dirname, 'db', 'migrations', '021_hot_opportunity_alerts.sql'));
+  // 2026-04-29 (Day 8.5): Opt-out tracking + match outcomes
+  await runMigrationFile('Optouts + outcomes (022)', path.join(__dirname, 'db', 'migrations', '022_optouts_and_match_outcomes.sql'));
   if (isQuantum) await runOutreachMigration();
 
   loadAllRoutes();
@@ -465,6 +467,20 @@ async function start() {
       cron.schedule('*/30 * * * *', async () => { try { await runOutreachEscalation(); } catch (e) {} });
       logger.info('[OutreachEscalation] ACTIVE - checking every 30 min');
     } catch (e) { logger.warn('[OutreachEscalation] Failed:', e.message); }
+
+    try {
+      const cron = require('node-cron');
+      const { runDailyDigest } = require('./cron/dailyDigestCron');
+      cron.schedule('0 8 * * *', async () => { try { await runDailyDigest(); } catch (e) {} }, { timezone: 'Asia/Jerusalem' });
+      logger.info('[DailyDigest] ACTIVE - 08:00 IL');
+    } catch (e) { logger.warn('[DailyDigest] Failed:', e.message); }
+
+    try {
+      const cron = require('node-cron');
+      const { runMatchAlerts } = require('./cron/matchAlertCron');
+      cron.schedule('*/10 * * * *', async () => { try { await runMatchAlerts(); } catch (e) {} });
+      logger.info('[MatchAlert] ACTIVE - every 10 min');
+    } catch (e) { logger.warn('[MatchAlert] Failed:', e.message); }
 
     try {
       const cron = require('node-cron');

--- a/src/index.js
+++ b/src/index.js
@@ -166,6 +166,7 @@ function loadAllRoutes() {
     { path: '/api/newsletter',         file: 'routes/newsletterRoutes.js' },
     { path: '/api/signatures',         file: 'routes/signatureRoutes.js' },
     { path: '/api/campaigns',          file: 'routes/campaignRoutes.js' },
+    { path: '/api',                    file: 'routes/hotOpportunitiesRoutes.js' },
     { path: '/api/appointments',       file: 'routes/appointmentRoutes.js' },
     { path: '/api/news',               file: 'routes/newsRoutes.js' },
     { path: '/api/publish',            file: 'routes/publishRoutes.js' },

--- a/src/index.js
+++ b/src/index.js
@@ -380,6 +380,8 @@ async function start() {
   await runMigrationFile('Hot opp alerts (021)', path.join(__dirname, 'db', 'migrations', '021_hot_opportunity_alerts.sql'));
   // 2026-04-29 (Day 8.5): Opt-out tracking + match outcomes
   await runMigrationFile('Optouts + outcomes (022)', path.join(__dirname, 'db', 'migrations', '022_optouts_and_match_outcomes.sql'));
+  // 2026-04-29 (Day 8.5): Unique index on listings(source, address, city) for yad2Scraper ON CONFLICT
+  await runMigrationFile('Listings unique idx (023)', path.join(__dirname, 'db', 'migrations', '023_listings_unique_index.sql'));
   if (isQuantum) await runOutreachMigration();
 
   loadAllRoutes();

--- a/src/public/dashboard.html
+++ b/src/public/dashboard.html
@@ -3052,7 +3052,7 @@
             const name = document.getElementById('qr-campaign-name').value.trim();
             if (!name) { alert('נא להזין שם קמפיין'); return; }
             try {
-                const data = await fetchJSON('/api/campaign/generate-link', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ campaign_name: name }) });
+                const data = await fetchJSON('/api/campaigns/generate-link', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ campaign_name: name }) });
                 if (!data.success) throw new Error(data.error);
                 _qrLink = data.link;
                 document.getElementById('qr-link-text').textContent = data.link;

--- a/src/routes/campaignRoutes.js
+++ b/src/routes/campaignRoutes.js
@@ -159,6 +159,16 @@ router.get('/', async (req, res) => {
   }
 });
 
+// POST /api/campaigns/generate-link — build UTM URL for a campaign name
+router.post('/generate-link', (req, res) => {
+  const name = (req.body?.campaign_name || '').toString().trim();
+  if (!name) return res.status(400).json({ success: false, error: 'campaign_name required' });
+  const slug = name.toLowerCase().replace(/[^a-z0-9]+/gi, '-').replace(/^-|-$/g, '') || 'campaign';
+  const base = process.env.PUBLIC_SITE_URL || 'https://u-r-quantum.com';
+  const url  = `${base}/?utm_source=quantum&utm_medium=campaign&utm_campaign=${encodeURIComponent(slug)}`;
+  res.json({ success: true, link: url, url, slug, utm: { source: 'quantum', medium: 'campaign', campaign: slug } });
+});
+
 // GET /api/campaigns/scripts/preview
 router.get('/scripts/preview', (req, res) => {
   const { name, city, propertyType } = req.query;

--- a/src/routes/chartRoutes.js
+++ b/src/routes/chartRoutes.js
@@ -50,7 +50,7 @@ router.get('/leads-by-source', async (req, res) => {
     SELECT
       COALESCE(NULLIF(utm_source, ''), NULLIF(source, ''), 'direct') AS source,
       COUNT(*)::int AS count
-    FROM leads
+    FROM website_leads
     GROUP BY 1
     ORDER BY count DESC
     LIMIT 20
@@ -96,7 +96,7 @@ router.get('/conversion-rate', async (req, res) => {
         COUNT(*) FILTER (WHERE status = 'closed')::numeric * 100.0 /
         NULLIF(COUNT(*), 0)
       , 2), 0)::float AS conversion_rate_percent
-    FROM leads
+    FROM website_leads
   `);
   const summary = rows[0] || {
     total_leads: 0, engaged: 0, qualified: 0, converted: 0, conversion_rate_percent: 0

--- a/src/routes/dashboardRoute.js
+++ b/src/routes/dashboardRoute.js
@@ -808,7 +808,6 @@ function generateDashboardHTML(stats) {
                 </select>
                 <input id="sched-search" type="text" placeholder="🔍 חיפוש שם / טלפון..." oninput="filterSchedulingTable()" class="filter-input" style="min-width:190px;width:auto;">
                 <button class="btn" data-onclick="loadScheduling()" style="margin-right:auto;">🔄 רענן</button>
-                <a href="/api/scheduling/campaign" target="_blank" class="btn btn-secondary">📊 דוח קמפיין</a>
             </div>
             <div id="sched-kpis" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:8px;margin-bottom:16px;"></div>
             <div id="sched-list" class="data-list"><div class="loading">טוען נתוני תיאומים...</div></div>

--- a/src/routes/hotOpportunitiesRoutes.js
+++ b/src/routes/hotOpportunitiesRoutes.js
@@ -41,4 +41,46 @@ router.get('/hot-opportunities', async (req, res) => {
   }
 });
 
+// Day 8.5 — opt-outs read endpoint
+router.get('/wa-optouts', async (req, res) => {
+  try {
+    const limit = Math.min(parseInt(req.query.limit, 10) || 100, 500);
+    const { rows } = await pool.query(`
+      SELECT id, phone, opted_out_at, source, reply_text, listing_id, notes
+      FROM wa_optouts
+      ORDER BY opted_out_at DESC
+      LIMIT $1
+    `, [limit]);
+    res.json({ success: true, count: rows.length, optouts: rows });
+  } catch (err) {
+    res.status(500).json({ success: false, error: err.message });
+  }
+});
+
+// Day 8.5 — recent matches across all leads (operator-wide view)
+router.get('/lead-matches', async (req, res) => {
+  try {
+    const limit = Math.min(parseInt(req.query.limit, 10) || 50, 200);
+    const minScore = parseFloat(req.query.min_score) || 0;
+    const { rows } = await pool.query(`
+      SELECT
+        m.id, m.lead_id, m.listing_id, m.score, m.created_at,
+        m.outcome, m.outcome_at, m.outcome_notes,
+        wl.name AS lead_name, wl.email AS lead_email, wl.phone AS lead_phone,
+        l.address, l.city, l.asking_price, l.url AS listing_url,
+        c.name AS complex_name, c.iai_score, c.enhanced_ssi_score
+      FROM lead_matches m
+      LEFT JOIN website_leads wl ON wl.id = m.lead_id
+      LEFT JOIN listings l ON l.id = m.listing_id
+      LEFT JOIN complexes c ON c.id = l.complex_id
+      WHERE m.score >= $2
+      ORDER BY m.created_at DESC
+      LIMIT $1
+    `, [limit, minScore]);
+    res.json({ success: true, count: rows.length, matches: rows });
+  } catch (err) {
+    res.status(500).json({ success: false, error: err.message });
+  }
+});
+
 module.exports = router;

--- a/src/routes/hotOpportunitiesRoutes.js
+++ b/src/routes/hotOpportunitiesRoutes.js
@@ -1,0 +1,44 @@
+/**
+ * Hot Opportunities read endpoint (Day 8 — surfaces what hotOpportunityCron writes).
+ *
+ * Mounted at /api so paths are:
+ *   GET /api/hot-opportunities              -- last N alerts with listing+complex context
+ *   GET /api/hot-opportunities?status=sent  -- filter by status
+ *   GET /api/hot-opportunities?limit=20     -- override default (50, max 200)
+ */
+const express = require('express');
+const router = express.Router();
+const pool = require('../db/pool');
+
+router.get('/hot-opportunities', async (req, res) => {
+  try {
+    const limit = Math.min(parseInt(req.query.limit, 10) || 50, 200);
+    const status = req.query.status;
+    const params = [];
+    let where = '';
+    if (status) {
+      where = 'WHERE a.status = $1';
+      params.push(status);
+    }
+    params.push(limit);
+    const { rows } = await pool.query(`
+      SELECT
+        a.id, a.listing_id, a.complex_id, a.iai_score, a.ssi_score,
+        a.match_score, a.channel, a.status, a.recipient,
+        a.message_preview, a.error, a.created_at,
+        l.address, l.city, l.asking_price, l.url AS listing_url, l.source,
+        c.name AS complex_name
+      FROM hot_opportunity_alerts a
+      LEFT JOIN listings  l ON l.id = a.listing_id
+      LEFT JOIN complexes c ON c.id = a.complex_id
+      ${where}
+      ORDER BY a.created_at DESC
+      LIMIT $${params.length}
+    `, params);
+    res.json({ success: true, count: rows.length, alerts: rows });
+  } catch (err) {
+    res.status(500).json({ success: false, error: err.message });
+  }
+});
+
+module.exports = router;

--- a/src/services/autoFirstContactService.js
+++ b/src/services/autoFirstContactService.js
@@ -111,13 +111,16 @@ async function saveOutgoingMessage(phone, message, listingId) {
 async function processYad2() {
     let contacted = 0, failed = 0, skipped = 0;
     try {
+        // Day 8.5 fix: removed the 2-hour window. Scrapers run once daily so the
+        // window meant only the morning's listings were ever contacted, leaving
+        // 1,000+ older listings stuck forever. Now we work the full backlog.
         const result = await pool.query(`
             SELECT id, phone, address, city, contact_name
             FROM listings
             WHERE contact_status IS NULL
               AND phone IS NOT NULL AND phone != ''
               AND is_active = TRUE
-              AND created_at > NOW() - INTERVAL '2 hours'
+            ORDER BY created_at DESC
             LIMIT 20
         `);
 
@@ -180,12 +183,13 @@ async function processFacebook() {
         );
         if (!tableCheck.rows.length) return { contacted: 0, failed: 0, skipped: 0 };
 
+        // Day 8.5 fix: removed the 2-hour window (same as Yad2 path).
         const result = await pool.query(`
             SELECT id, phone, address, city, contact_name
             FROM facebook_ads
             WHERE contact_status IS NULL
               AND phone IS NOT NULL AND phone != ''
-              AND created_at > NOW() - INTERVAL '2 hours'
+            ORDER BY created_at DESC
             LIMIT 20
         `).catch(() => ({ rows: [] }));
 

--- a/src/services/backupService.js
+++ b/src/services/backupService.js
@@ -81,16 +81,28 @@ async function createDatabaseBackup(filename) {
     try {
         logger.info(`💾 Starting database backup: ${filename}`);
         
-        // Use pg_dump to create compressed backup
-        const dumpCommand = `pg_dump "${DATABASE_URL}" | gzip > "${tempPath}"`;
-        
+        // Day 8.5 fix: use pipefail so pg_dump failures aren't swallowed by gzip.
+        // Previously, when pg_dump failed (e.g., binary missing or version mismatch)
+        // gzip happily produced an empty .gz file that "succeeded" — we'd write
+        // an empty backup and only catch it later in verifyBackup. With pipefail,
+        // any pg_dump failure exits the pipe with non-zero and execSync throws.
+        const dumpCommand = `bash -c 'set -o pipefail; pg_dump "${DATABASE_URL}" --no-owner --no-acl | gzip > "${tempPath}"'`;
+
         const startTime = Date.now();
-        execSync(dumpCommand, { 
+        execSync(dumpCommand, {
             stdio: ['ignore', 'pipe', 'pipe'],
             timeout: 300000, // 5 minutes timeout
             maxBuffer: 100 * 1024 * 1024 // 100MB buffer
         });
         const duration = Date.now() - startTime;
+
+        // Belt & suspenders: reject obviously-empty backups before they're moved
+        // into the backups dir. A real Quantum backup is at least ~50KB even
+        // when there's no data (system catalogs + schema).
+        const tempStats = await fs.stat(tempPath).catch(() => null);
+        if (!tempStats || tempStats.size < 1024) {
+            throw new Error(`pg_dump produced suspiciously small output (${tempStats?.size || 0} bytes) — check pg_dump binary + DATABASE_URL`);
+        }
         
         // Move temp file to final location
         await fs.rename(tempPath, backupPath);

--- a/src/services/optoutService.js
+++ b/src/services/optoutService.js
@@ -1,0 +1,73 @@
+/**
+ * Opt-out Service (Day 8.5).
+ *
+ * Records phones that asked to stop receiving QUANTUM WhatsApp outreach,
+ * and provides a fast check for the bulk-outreach cron + incoming-WA cron.
+ *
+ * Compliance: Meta Marketing templates require honoring opt-out requests.
+ */
+const pool = require('../db/pool');
+const { logger } = require('./logger');
+
+// Hebrew + English keywords. We match on the trimmed body (case-insensitive).
+const OPTOUT_KEYWORDS = [
+  'הסר', 'הסירו', 'תפסיקו', 'תפסיק', 'תורידו', 'אנא הסירו אותי',
+  'stop', 'unsubscribe', 'remove me', 'no thanks',
+];
+
+function matchOptoutKeyword(text) {
+  if (!text) return null;
+  const t = text.trim().toLowerCase();
+  for (const kw of OPTOUT_KEYWORDS) {
+    const k = kw.toLowerCase();
+    // Exact match (single-word reply) or substring with word boundary.
+    if (t === k) return kw;
+    if (t.length <= 30 && t.includes(k)) return kw;
+  }
+  return null;
+}
+
+function normalizePhone(phone) {
+  if (!phone) return null;
+  let p = String(phone).replace(/\D/g, '');
+  if (p.startsWith('972') && p.length === 12) return '0' + p.slice(3);
+  return p || null;
+}
+
+async function isOptedOut(phone) {
+  const p = normalizePhone(phone);
+  if (!p) return false;
+  try {
+    const { rows } = await pool.query(
+      'SELECT 1 FROM wa_optouts WHERE phone = $1 LIMIT 1', [p]
+    );
+    return rows.length > 0;
+  } catch (e) {
+    logger.warn('[Optout] isOptedOut check failed:', e.message);
+    return false;
+  }
+}
+
+async function recordOptout({ phone, source, replyText = null, listingId = null, notes = null }) {
+  const p = normalizePhone(phone);
+  if (!p) return { ok: false, error: 'invalid_phone' };
+  try {
+    await pool.query(
+      `INSERT INTO wa_optouts (phone, source, reply_text, listing_id, notes)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (phone) DO UPDATE SET
+         opted_out_at = NOW(),
+         source       = EXCLUDED.source,
+         reply_text   = EXCLUDED.reply_text,
+         notes        = EXCLUDED.notes`,
+      [p, source, replyText, listingId, notes]
+    );
+    logger.info(`[Optout] Recorded ${p} via ${source}`);
+    return { ok: true };
+  } catch (e) {
+    logger.error('[Optout] Insert failed:', e.message);
+    return { ok: false, error: e.message };
+  }
+}
+
+module.exports = { matchOptoutKeyword, isOptedOut, recordOptout, OPTOUT_KEYWORDS };


### PR DESCRIPTION
## Summary
Three waves of fixes in this PR.

### Wave 1 — Surface gaps (e270712)
- New `GET /api/hot-opportunities`, new `POST /api/campaigns/generate-link`
- Drop dead `/api/scheduling/campaign` button (Minhelet-only route)
- `dashboard.html` switched to plural `/api/campaigns/generate-link`

### Wave 2 — Bot compliance + visibility (f75131a)
- Migration 022: `wa_optouts` + `lead_matches.outcome*` columns
- New `optoutService` (Hebrew + English keyword detection)
- `bulkOutreachCron` skips opted-out phones via `LEFT JOIN wa_optouts`
- `incomingWhatsAppCron` detects opt-out keywords BEFORE bot routing
- New `dailyDigestCron` 08:00 IL — ops summary, catches stalled crons
- New `matchAlertCron` every 10 min — alerts on score>=80
- New `GET /api/wa-optouts` and `GET /api/lead-matches`

### Wave 3 — 4 production bugs found in Railway logs (d78648f)
1. **AutoFirstContact 2h window** — was leaving 1,117 listings stuck forever. Removed filter, now works the full backlog.
2. **yad2Scraper ON CONFLICT crash** — Migration 023 adds the missing unique expression index `uq_listings_source_address_city`. Was silently dropping ~5-10 listings per batch.
3. **chartRoutes `FROM leads`** — table is `website_leads`. Fixed `/leads-by-source` and `/conversion-rate`.
4. **Backup empty SQL dumps** — added `set -o pipefail` so pg_dump failures aren't swallowed by gzip + size sanity check before move.

## Risk: low
All changes are additive (new tables/endpoints/crons/migrations) or replace broken behavior with working behavior.

| Change | Risk |
|---|---|
| New endpoints + new crons | none — read-only / new path |
| Migration 022 (wa_optouts + outcomes) | none — additive |
| Migration 023 (listings unique idx) | low — pre-dedupe via is_active=FALSE, no row delete |
| AutoFirstContact filter relaxed | none — contact_status IS NULL still gates |
| chartRoutes table rename | none — old query was throwing |
| Backup pipefail | none — failure mode now louder, not destructive |

## Test plan
- [x] `node -c` passes on all 11 modified/new files
- [ ] After merge+deploy: `[MasterPipeline]` no more `Failed to process listing` warnings
- [ ] After deploy: `/api/auto-contact/stats` shows pending decreasing over time
- [ ] After deploy: `/api/chart/leads-by-source` returns 200 with data
- [ ] After deploy: backup logs show real size (>50KB) or fail-fast loud
- [ ] After deploy: `/api/hot-opportunities`, `/api/wa-optouts`, `/api/lead-matches` return 200