### PR TITLE
Day 9: Komo lookup speedup + GitHub backup PAT renewal doc

### DIFF
--- a/docs/github-backup-setup.md
+++ b/docs/github-backup-setup.md
@@ -1,0 +1,45 @@
+# GitHub Backup Token — Renewal
+
+The `[Backup] ❌ Cannot access backup repo: GitHub API error 401: Bad credentials`
+log line means `GITHUB_BACKUP_TOKEN` in Railway is rejected by GitHub. The token
+either expired or was revoked. Generate a new one and update Railway env.
+
+## 1. Generate a new fine-grained PAT
+
+1. Open https://github.com/settings/tokens?type=beta
+2. **Generate new token**
+3. **Token name:** `quantum-backup-railway` (anything works)
+4. **Expiration:** 1 year (or "No expiration" if you don't want to rotate)
+5. **Repository access:** Only select repositories → `hemichaeli/pinuy-binuy-backups`
+6. **Permissions:**
+   - Repository → **Contents**: **Read and write**
+   - Repository → **Metadata**: **Read** (auto-selected)
+7. **Generate token** — copy the `github_pat_...` value (shown once).
+
+## 2. Update Railway env var
+
+Either via the dashboard:
+- https://railway.com/project/145d8345-978c-4abb-a792-a46ece2f1b9f
+- Service `pinuy-binuy-analyzer` → Variables → `GITHUB_BACKUP_TOKEN` → paste new value → Save
+
+Or via CLI / MCP (replace `<NEW_TOKEN>`):
+```
+mcp__railway__set_variable
+  projectId: 145d8345-978c-4abb-a792-a46ece2f1b9f
+  environmentId: ac35918c-66aa-405e-871e-fce81f8f81b9
+  serviceId: e827f187-00fa-498e-9fc0-26d85beabf5e
+  name: GITHUB_BACKUP_TOKEN
+  value: <NEW_TOKEN>
+```
+
+## 3. Verify
+
+After Railway redeploys (~60s):
+
+```bash
+curl -X POST "https://pinuy-binuy-analyzer-production.up.railway.app/api/backup/github/create"
+```
+
+Expected: `{"success":true,...}` plus a new commit on `hemichaeli/pinuy-binuy-backups`
+under `backups/YYYY-MM-DD/HH-mm-ss/`. The hourly cron at `5 * * * *` will then
+take over automatically.

--- a/src/services/phoneRevealOrchestrator.js
+++ b/src/services/phoneRevealOrchestrator.js
@@ -502,45 +502,70 @@ async function tryYad2ApiPhone(itemId) {
 // ── Method 4b: Komo phone API for yad2 listings (cross-platform enrichment) ──
 // Many yad2 listings also appear on Komo. Use address matching to find them.
 
-async function tryKomoForYad2Listing(listing) {
+// Day 9: Komo cross-platform lookup, optimized for speed.
+// - Cache search results by city (most useful) + city+street to avoid repeating the same HTML pull.
+// - Reduced timeout (4s) and modaaNum cap (3) — 8 was overkill, the right match is usually in the first few.
+// - Skip URL #2 if URL #1 returned candidates (saves ~5s per listing).
+// - Module-level cache survives across listings within same enrichAllPhones run.
+const _komoSearchCache = new Map(); // "city" or "city|street" → array<modaaNum>
+
+async function tryKomoForYad2Listing(listing, options = {}) {
   if (!listing.address || !listing.city) return null;
   const street = listing.address.replace(/\d+/g, '').trim();
   if (!street || street.length < 2) return null;
 
-  // Try multiple Komo URL patterns
-  const searchUrls = [
-    `${KOMO_BASE}/code/nadlan/apartments-for-sale.asp?cityTxt=${encodeURIComponent(listing.city)}&streetTxt=${encodeURIComponent(street)}&luachNum=2`,
-    `${KOMO_BASE}/code/nadlan/apartments-for-sale.asp?cityTxt=${encodeURIComponent(listing.city)}&luachNum=2`,
-  ];
+  const cache = options.cache || _komoSearchCache;
 
-  for (const url of searchUrls) {
+  // Try city+street cache first; fall back to city-wide cache
+  const tightKey = `${listing.city}|${street}`;
+  const cityKey  = listing.city;
+
+  let modaas = cache.get(tightKey) || cache.get(cityKey);
+
+  if (!modaas) {
+    // Only one network call: prefer narrow URL, fall back to broad once if no hits.
+    const narrowUrl = `${KOMO_BASE}/code/nadlan/apartments-for-sale.asp?cityTxt=${encodeURIComponent(listing.city)}&streetTxt=${encodeURIComponent(street)}&luachNum=2`;
     try {
-      const r = await axios.get(url, {
-        headers: { ...KOMO_HEADERS, 'Accept': 'text/html' },
-        timeout: 10000
+      const r = await axios.get(narrowUrl, {
+        headers: { ...KOMO_HEADERS, 'Accept': 'text/html' }, timeout: 4000
       });
-
       if (typeof r.data === 'string') {
-        // Extract modaaNum links from the search results page
-        const modaaMatches = r.data.match(/modaaNum=(\d+)/g) || [];
-        const uniqueModaas = [...new Set(modaaMatches.map(m => m.replace('modaaNum=', '')))];
-
-        // Match by address to find the right listing
-        const houseNum = listing.address.match(/\d+/)?.[0];
-        const streetWords = street.split(/[\s,]+/).filter(w => w.length > 1);
-
-        for (const modaaNum of uniqueModaas.slice(0, 8)) {
-          const phoneResult = await fetchKomoPhone(modaaNum);
-          if (phoneResult.phone) {
-            logger.debug(`[PhoneOrch] Komo cross-match: ${listing.address} → ${phoneResult.phone} (via komo #${modaaNum})`);
-            return phoneResult;
-          }
-          await sleep(400);
-        }
+        const matches = r.data.match(/modaaNum=(\d+)/g) || [];
+        modaas = [...new Set(matches.map(m => m.replace('modaaNum=', '')))];
+        cache.set(tightKey, modaas);
       }
     } catch (err) {
-      logger.debug(`[PhoneOrch] Komo cross-search failed for ${listing.address}: ${err.message}`);
+      logger.debug(`[PhoneOrch] Komo narrow search failed for ${listing.address}: ${err.message}`);
     }
+
+    if (!modaas || modaas.length === 0) {
+      // Broad fallback (city only) — cached city-wide so 50 listings in same city = 1 call.
+      const broadUrl = `${KOMO_BASE}/code/nadlan/apartments-for-sale.asp?cityTxt=${encodeURIComponent(listing.city)}&luachNum=2`;
+      try {
+        const r = await axios.get(broadUrl, {
+          headers: { ...KOMO_HEADERS, 'Accept': 'text/html' }, timeout: 4000
+        });
+        if (typeof r.data === 'string') {
+          const matches = r.data.match(/modaaNum=(\d+)/g) || [];
+          modaas = [...new Set(matches.map(m => m.replace('modaaNum=', '')))];
+          cache.set(cityKey, modaas);
+        }
+      } catch (err) {
+        logger.debug(`[PhoneOrch] Komo broad search failed for ${listing.address}: ${err.message}`);
+      }
+    }
+  }
+
+  if (!modaas || modaas.length === 0) return null;
+
+  // Try first 3 modaaNums (most likely matches at top of results page)
+  for (const modaaNum of modaas.slice(0, 3)) {
+    const phoneResult = await fetchKomoPhone(modaaNum);
+    if (phoneResult && phoneResult.phone) {
+      logger.debug(`[PhoneOrch] Komo cross-match: ${listing.address} → ${phoneResult.phone} (via komo #${modaaNum})`);
+      return phoneResult;
+    }
+    await sleep(200);
   }
   return null;
 }
@@ -855,35 +880,43 @@ async function enrichAllPhones(options = {}) {
     logger.info(`[PhoneOrch] Pass 3.5: Komo cross-platform lookup for ${allStillNeedPhone.length} listings (all platforms)...`);
     results.passes.komo_cross.attempted = allStillNeedPhone.length;
 
-    // Cache city+street searches to avoid repeated lookups
-    const searchCache = new Map(); // "city|street" → modaaNums[]
+    // Day 9: shared cache so multiple listings in the same city/street reuse one search.
+    const searchCache = new Map();
     let crossFound = 0;
     let errors = 0;
+    const startTime = Date.now();
+    const MAX_DURATION_MS = 5 * 60 * 1000; // hard cap: 5 minutes for the entire pass
 
     for (const listing of allStillNeedPhone) {
       if (errors > 10) {
         logger.warn(`[PhoneOrch] Too many Komo errors (${errors}), stopping cross-lookup`);
         break;
       }
-
-      const result = await tryKomoForYad2Listing(listing);
-      if (result && result.phone) {
-        if (!dryRun) {
-          await pool.query(
-            `UPDATE listings SET phone = $1, contact_name = COALESCE($2, contact_name), updated_at = NOW() WHERE id = $3`,
-            [result.phone, result.contact_name, listing.id]
-          );
-        }
-        markEnriched(listing.id, result.phone, result.contact_name, 'komo_cross');
-        crossFound++;
-        errors = 0; // Reset error counter on success
-      } else {
-        // Only count as error if we got a network failure
-        // (no result found is normal)
+      if (Date.now() - startTime > MAX_DURATION_MS) {
+        logger.warn(`[PhoneOrch] Komo cross-lookup time cap reached (${Math.round((Date.now()-startTime)/1000)}s), stopping early`);
+        break;
       }
-      await sleep(1000);
+
+      try {
+        const result = await tryKomoForYad2Listing(listing, { cache: searchCache });
+        if (result && result.phone) {
+          if (!dryRun) {
+            await pool.query(
+              `UPDATE listings SET phone = $1, contact_name = COALESCE($2, contact_name), updated_at = NOW() WHERE id = $3`,
+              [result.phone, result.contact_name, listing.id]
+            );
+          }
+          markEnriched(listing.id, result.phone, result.contact_name, 'komo_cross');
+          crossFound++;
+          errors = Math.max(0, errors - 1); // gradually decay errors on success
+        }
+      } catch (err) {
+        errors++;
+        logger.debug(`[PhoneOrch] Komo cross-lookup error for listing ${listing.id}: ${err.message}`);
+      }
+      await sleep(200);
     }
-    logger.info(`[PhoneOrch] Pass 3.5 complete: ${results.passes.komo_cross.enriched} phones from Komo cross-lookup (checked ${allStillNeedPhone.length})`);
+    logger.info(`[PhoneOrch] Pass 3.5 complete: ${results.passes.komo_cross.enriched} phones from Komo cross-lookup (checked ${allStillNeedPhone.length}, cache size=${searchCache.size}, duration=${Math.round((Date.now()-startTime)/1000)}s)`);
   }
 
   // ── PASS 4: Direct page scraping (for non-Cloudflare sites) ───────────────


### PR DESCRIPTION
## Summary
Two fixes in one PR:

### 1. Komo cross-platform lookup speedup (code)
The Pass 3.5 'Komo cross-platform lookup for 35 listings' we saw in Railway logs was effectively stuck — root cause was sequential-everything with **no caching**:
- per-listing × per-URL (2 sequential) × per-modaaNum (up to 8 sequential) × 1000ms inter-listing sleep
- The 'searchCache = new Map()' was declared and never used
- Worst case: 25+ minutes for 35 listings

Fixes:
- Implement the cache (city+street, fall back to city-wide). 50 listings in one city = 1 search.
- Reduce timeout 10s → 4s
- Cap modaaNum lookups 8 → 3
- Skip URL #2 if URL #1 returned candidates
- Hard cap 5 min on the whole Pass 3.5 — it always terminates now
- Inter-listing sleep 1000ms → 200ms
- Replace dead error-counter logic with real error increment + decay-on-success

### 2. GitHub backup PAT renewal doc
`[Backup] ❌ Cannot access backup repo: GitHub API error 401: Bad credentials` — token expired. Cannot regenerate in code; `docs/github-backup-setup.md` walks through the manual PAT generation + Railway env var update.

## Risk: low
- Code change is pure optimization of an existing function. Signature back-compat (`options.cache` is optional).
- Tighter Komo timeouts may fail-fast on a few slow searches, but Pass 4 (direct scrape) catches the same listings downstream.
- 5-min cap means downstream passes (Pass 4, etc.) always run instead of being blocked.

## Test plan
- [ ] After deploy: trigger `POST /api/messaging/enrich-all-phones` with limit=200
- [ ] Logs show 'Pass 3.5 complete' line (currently never logs that)
- [ ] Cache size in completion log > 0 (proof the cache is being used)
- [ ] Pass 4 starts (proof Pass 3.5 didn't block forever)