### PR TITLE
Day 10: dashboard listings tab — 4 UX fixes

### DIFF
--- a/src/public/dashboard.html
+++ b/src/public/dashboard.html
@@ -402,9 +402,11 @@
                 <input type="text" class="filter-input" id="cityFilter" placeholder="עיר">
                 <input type="number" class="filter-input" id="minPriceFilter" placeholder="מחיר מינימום">
                 <input type="number" class="filter-input" id="maxPriceFilter" placeholder="מחיר מקסימום">
-                <select class="filter-select" id="phoneFilter">
+                <select class="filter-select" id="phoneFilter" onchange="loadAds()">
                     <option value="">כל הטלפון</option>
-                    <option value="yes">יש טלפון</option>
+                    <option value="mobile">📱 נייד בלבד (WhatsApp)</option>
+                    <option value="yes">יש טלפון (כולל נייח)</option>
+                    <option value="landline">📞 נייח בלבד</option>
                     <option value="no">אין טלפון</option>
                 </select>
                 <select class="filter-select" id="adsSortBy" onchange="loadAds()">
@@ -435,7 +437,7 @@
                     <tr id="ads-thead">
                         <th onclick="sortAdsBy('title')" data-sort-field="title">Property</th>
                         <th onclick="sortAdsBy('complex_status')" data-sort-field="complex_status">Status</th>
-                        <th>Performance Trend</th>
+                        <th title="ירידת מחיר מצטברת מאז תחילת המכירה — מדד לחץ מוכר אמיתי">ירידת מחיר ▼</th>
                         <th onclick="sortAdsBy('asking_price')" data-sort-field="asking_price">מחיר קנייה</th>
                         <th onclick="sortAdsBy('premium_percent')" data-sort-field="premium_percent">פרמייה %</th>
                         <th title="מחיר מכירה מוערך אחרי הפרויקט">מחיר מכירה מוערך</th>
@@ -1462,14 +1464,21 @@
                     + '</div><div style="font-size:11px;color:var(--text-muted);">' + (ad.city || '') + (ad.address ? ' | ' + ad.address.substring(0,30) : '') + '</div></div>'
                     + '</div></td>'
                     + '<td>' + statusBadge(adStatus) + '</td>'
-                    + '<td>' + miniSparkline(sparkColor) + '</td>'
+                    + (function(){
+                        // Day 10: replaced fake random sparkline with real price-drop indicator.
+                        // total_price_drop_percent comes from listings table (computed by SSI batch).
+                        var drop = parseFloat(ad.total_price_drop_percent || 0);
+                        if (!drop || drop <= 0) return '<td style="color:var(--text-muted);text-align:center;">—</td>';
+                        var color = drop > 15 ? 'var(--green)' : drop > 5 ? 'var(--gold)' : 'var(--text-secondary)';
+                        return '<td style="color:' + color + ';font-weight:700;font-size:13px;text-align:center;">▼' + drop.toFixed(1) + '%</td>';
+                      })()
                     + '<td style="color:var(--text-primary);font-weight:600;font-size:14px;">' + price + '</td>'
                     + '<td style="color:' + premNowColor + ';font-weight:600;">' + premNow + '</td>'
                     + '<td style="color:var(--blue);font-weight:600;font-size:13px;">' + (ad.estimated_sale_price ? '\u20AA' + parseInt(ad.estimated_sale_price).toLocaleString() : '\u2014') + '</td>'
                     + '<td style="color:var(--green);font-weight:700;font-size:13px;">' + (ad.profit_delta_ils && parseFloat(ad.profit_delta_ils) > 0 ? '+\u20AA' + parseInt(ad.profit_delta_ils).toLocaleString() : '\u2014') + '</td>'
                     + '<td>' + (ad.area_sqm ? parseFloat(ad.area_sqm).toFixed(0) + ' מ"ר' : '\u2014') + '</td>'
                     + '<td>' + (ad.rooms || '\u2014') + '</td>'
-                    + '<td style="color:' + ssiColor + ';font-weight:600;" title="SSI: ' + ssi + ' | זמן: ' + (ad.ssi_time_score||0) + ' | מחיר: ' + (ad.ssi_price_score||0) + ' | אינדיקטורים: ' + (ad.ssi_indicator_score||0) + '">' + (ssi || '\u2014') + '</td>'
+                    + '<td style="color:' + ssiColor + ';font-weight:600;" title="SSI: ' + ssi + ' | זמן: ' + (ad.ssi_time_score||0) + ' | מחיר: ' + (ad.ssi_price_score||0) + ' | אינדיקטורים: ' + (ad.ssi_indicator_score||0) + '">' + (ad.ssi_score === null || ad.ssi_score === undefined ? '\u2014' : String(ad.ssi_score)) + '</td>'
                     + '<td>' + (ad.phone ? '<a href="tel:' + ad.phone + '" style="color:var(--blue);font-size:12px;">' + ad.phone + '</a>' : '<span style="color:var(--text-muted);font-size:11px;">אין</span>') + '</td>'
                     + '<td><div style="display:flex;gap:6px;">'
                     + '<button class="btn" style="padding:5px 12px;font-size:12px;background:var(--green);color:#000;" onclick="openSendModal(' + ad.id + ',\'' + (ad.source||'').replace(/\'/g,'') + '\',\'' + encodeURIComponent(title||'') + '\',\'' + (ad.url||'').replace(/\'/g,'') + '\',\'' + (ad.phone||'').replace(/\'/g,'') + '\')">💬 שלח</button>'

--- a/src/routes/dashboardRoute.js
+++ b/src/routes/dashboardRoute.js
@@ -144,8 +144,12 @@ router.get('/api/ads', async (req, res) => {
         if (minPrice && !isNaN(minPrice)) { query += ` AND l.asking_price >= $${n}`; params.push(parseInt(minPrice)); n++; }
         if (maxPrice && !isNaN(maxPrice)) { query += ` AND l.asking_price <= $${n}`; params.push(parseInt(maxPrice)); n++; }
         if (search?.trim()) { query += ` AND (l.address ILIKE $${n} OR l.city ILIKE $${n})`; params.push('%' + search.trim() + '%'); n++; }
+        // Day 10: phone filter expanded — distinguish mobile (WA-able) vs landline.
+        // Israeli mobile prefixes: 050-059. Strip non-digits before matching.
         if (phoneFilter === 'yes') query += ` AND l.phone IS NOT NULL AND l.phone != ''`;
         else if (phoneFilter === 'no') query += ` AND (l.phone IS NULL OR l.phone = '')`;
+        else if (phoneFilter === 'mobile') query += ` AND l.phone IS NOT NULL AND l.phone != '' AND regexp_replace(l.phone, '\\D', '', 'g') ~ '^(972)?0?5[0-9]'`;
+        else if (phoneFilter === 'landline') query += ` AND l.phone IS NOT NULL AND l.phone != '' AND regexp_replace(l.phone, '\\D', '', 'g') !~ '^(972)?0?5[0-9]'`;
         if (contactStatus) { query += ` AND l.message_status = $${n}`; params.push(contactStatus); n++; }
         const validSort = ['address', 'city', 'asking_price', 'created_at', 'ssi_score', 'area_sqm', 'rooms', 'floor', 'estimated_sale_price', 'profit_delta_ils'];
         const computedSorts = { estimated_sale_price: 'estimated_sale_price', profit_delta_ils: 'profit_delta_ils' };
@@ -161,6 +165,8 @@ router.get('/api/ads', async (req, res) => {
         if (city?.trim()) { countQuery += ` AND l.city ILIKE $${cn}`; countParams.push('%' + city.trim() + '%'); cn++; }
         if (phoneFilter === 'yes') countQuery += ` AND l.phone IS NOT NULL AND l.phone != ''`;
         else if (phoneFilter === 'no') countQuery += ` AND (l.phone IS NULL OR l.phone = '')`;
+        else if (phoneFilter === 'mobile') countQuery += ` AND l.phone IS NOT NULL AND l.phone != '' AND regexp_replace(l.phone, '\\D', '', 'g') ~ '^(972)?0?5[0-9]'`;
+        else if (phoneFilter === 'landline') countQuery += ` AND l.phone IS NOT NULL AND l.phone != '' AND regexp_replace(l.phone, '\\D', '', 'g') !~ '^(972)?0?5[0-9]'`;
         const countResult = await pool.query(countQuery, countParams);
         res.json({ success: true, data: result.rows, pagination: { page: parseInt(page), limit: parseInt(limit), total: parseInt(countResult.rows[0]?.total) || 0 } });
     } catch (error) {


### PR DESCRIPTION
Fixes 4 issues in the listings tab the operator flagged:

1. **Phone filter didn't trigger reload** — added onchange + expanded to 4 options (mobile-only / any-phone / landline / none)
2. **SSI showed em-dash for all rows** — `ssi || '—'` made 0 render as dash; fixed with explicit null check
3. **Performance Trend was Math.random()** — replaced with real total_price_drop_percent
4. **WhatsApp clarity** — most phones (90%) are actually mobile/WA-able; new filter makes this explicit

## Risk: low
- Existing yes/no filter values unchanged
- SSI=0 now renders correctly as '0' (was '—')
- Random sparkline replaced with real data column

## Test plan after deploy
- [ ] Listings tab → phone filter → 'נייד בלבד' shows ~877 listings
- [ ] Listings tab → phone filter → 'נייח בלבד' shows ~35 listings
- [ ] SSI column shows actual numbers (0, 50, 75, etc.) not all em-dashes
- [ ] Old 'Performance Trend' column now shows ירידת מחיר ▼ with real %s