### PR TITLE
Day 10: data fix — yad1 URLs (yad1.co.il is 404)

### DIFF
--- a/src/db/migrations/024_cleanup_bad_yad1_urls.sql
+++ b/src/db/migrations/024_cleanup_bad_yad1_urls.sql
@@ -1,0 +1,33 @@
+-- Migration 024: clean up yad1 listings with non-yad1 URLs (Day 10).
+--
+-- yad1.co.il is currently returning 404 — the platform appears defunct.
+-- The yad1Scraper falls back to Perplexity, which returns yad2.co.il
+-- search-page URLs as best-effort guesses. These leaked into the listings
+-- table as source='yad1' with url='https://www.yad2.co.il/...'.
+--
+-- Live count before this migration: ~101 of 108 yad1 listings have a
+-- yad2.co.il URL instead of a yad1.co.il URL.
+--
+-- Action: NULL out the misleading URLs. Listings stay active so the
+-- operator can still see them and contact via WhatsApp if a phone
+-- exists; the modal's URL-host validation now correctly degrades
+-- platform_chat for these cases.
+
+UPDATE listings
+SET url = NULL,
+    updated_at = NOW()
+WHERE source = 'yad1'
+  AND url IS NOT NULL
+  AND url NOT ILIKE 'https://%yad1.co.il/%'
+  AND url NOT ILIKE 'http://%yad1.co.il/%';
+
+-- Deactivate yad1 listings that now have no usable contact mechanism
+-- (no phone AND no URL). They'd just clutter the dashboard with manual-only
+-- fallback rows and the operator can't reach them anyway.
+UPDATE listings
+SET is_active = FALSE,
+    updated_at = NOW()
+WHERE source = 'yad1'
+  AND is_active = TRUE
+  AND (phone IS NULL OR phone = '')
+  AND (url IS NULL OR url = '');

--- a/src/index.js
+++ b/src/index.js
@@ -382,6 +382,8 @@ async function start() {
   await runMigrationFile('Optouts + outcomes (022)', path.join(__dirname, 'db', 'migrations', '022_optouts_and_match_outcomes.sql'));
   // 2026-04-29 (Day 8.5): Unique index on listings(source, address, city) for yad2Scraper ON CONFLICT
   await runMigrationFile('Listings unique idx (023)', path.join(__dirname, 'db', 'migrations', '023_listings_unique_index.sql'));
+  // 2026-04-30 (Day 10): clean up yad1 listings with non-yad1 URLs (yad1.co.il is 404)
+  await runMigrationFile('Bad yad1 URL cleanup (024)', path.join(__dirname, 'db', 'migrations', '024_cleanup_bad_yad1_urls.sql'));
   if (isQuantum) await runOutreachMigration();
 
   loadAllRoutes();

--- a/src/services/yad1Scraper.js
+++ b/src/services/yad1Scraper.js
@@ -57,11 +57,24 @@ async function queryYad1Direct(city, limit = 50) {
   }
 }
 
+// Day 10: yad1.co.il returns 404 — the platform appears defunct. Until that
+// changes, validate any URL claiming to be yad1 actually points at yad1.co.il.
+// Otherwise the listing isn't real and shouldn't be saved (or should be
+// flagged so it doesn't leak into the operator's send queue).
+function isValidYad1Url(u) {
+  if (!u || typeof u !== 'string') return false;
+  return /^https?:\/\/(www\.)?yad1\.co\.il\//i.test(u);
+}
+
 function parseYad1Item(item, defaultCity) {
   const phone = item.phone || item.contactPhone || item.contact?.phone || null;
   const price = parseInt(String(item.price || item.askingPrice || '').replace(/\D/g, '')) || null;
   const thumbnail = item.images?.[0]?.src || item.images?.[0]?.url ||
     item.thumbnail || item.cover_image || item.image || item.img_url || null;
+  // Only keep URL if it's actually a yad1 URL; otherwise null so the modal
+  // routes correctly (manual fallback rather than offering broken platform_chat).
+  const rawUrl = item.url || (item.id ? `https://www.yad1.co.il/item/${item.id}` : null);
+  const url = isValidYad1Url(rawUrl) ? rawUrl : null;
   return {
     source: 'yad1',
     listing_id: String(item.id || item.adId || ''),
@@ -73,7 +86,7 @@ function parseYad1Item(item, defaultCity) {
     floor: parseInt(item.floor || 0) || null,
     phone: cleanPhone(phone),
     contact_name: item.contactName || item.sellerName || null,
-    url: item.url || (item.id ? `https://www.yad1.co.il/item/${item.id}` : null),
+    url,
     description: (item.description || item.title || '').substring(0, 500),
     thumbnail_url: thumbnail
   };
@@ -135,7 +148,10 @@ async function queryYad1Perplexity(city) {
       floor: parseInt(item.floor) || null,
       phone: cleanPhone(item.phone),
       contact_name: item.contact_name || null,
-      url: item.url || null,
+      // Perplexity often returns yad2 search-page URLs when answering yad1
+      // queries (yad1.co.il is 404). Drop non-yad1 URLs so the modal won't
+      // offer a broken 'platform_chat' route.
+      url: isValidYad1Url(item.url) ? item.url : null,
       description: (item.description || '').substring(0, 500)
     }));
   } catch (err) {


### PR DESCRIPTION
Fixes the underlying data quality bug behind operator's complaint about yad1 listings.

## Root cause
yad1.co.il returns HTTP 404 — the site is defunct. yad1Scraper falls back to Perplexity which returns **yad2.co.il search-page URLs** as guesses. **101 of 108** yad1 listings in production have yad2.co.il URLs.

## Fixes
1. `parseYad1Item` + `queryYad1Perplexity` now validate URL is actually yad1.co.il; otherwise set to null
2. Migration 024 retroactively cleans existing data:
   - NULL out non-yad1 URLs
   - Deactivate yad1 listings with no phone AND no URL (uncontactable)

## Risk: low
- URL=null causes graceful modal fallback (already wired in PR #30)
- Migration only NULLs URLs and deactivates uncontactable rows
- 88 yad1 listings WITH phone remain unaffected

## Note
yad1.co.il being defunct = larger conversation. Retiring the scraper entirely is the cleaner long-term fix; out of scope here.