### PR TITLE
Day 10: retire yad1 scraper (platform defunct)

### DIFF
--- a/src/db/migrations/025_retire_yad1_listings.sql
+++ b/src/db/migrations/025_retire_yad1_listings.sql
@@ -1,0 +1,19 @@
+-- Migration 025: retire all yad1 listings (Day 10).
+--
+-- yad1.co.il returns HTTP 404 — the platform is defunct. The yad1Scraper
+-- was falling back to Perplexity, which generated fake listings with
+-- yad2.co.il search-page URLs.
+--
+-- The scraper cron has been disabled in src/index.js (commented out).
+-- This migration deactivates all existing yad1 listings so they stop
+-- polluting the dashboard. Same listings (where real) are also being
+-- scraped by the yad2 scraper, so coverage is unchanged.
+--
+-- Soft delete (is_active=FALSE) preserves history; if yad1 ever revives,
+-- can be reactivated by setting is_active=TRUE.
+
+UPDATE listings
+SET is_active = FALSE,
+    updated_at = NOW()
+WHERE source = 'yad1'
+  AND is_active = TRUE;

--- a/src/index.js
+++ b/src/index.js
@@ -384,6 +384,8 @@ async function start() {
   await runMigrationFile('Listings unique idx (023)', path.join(__dirname, 'db', 'migrations', '023_listings_unique_index.sql'));
   // 2026-04-30 (Day 10): clean up yad1 listings with non-yad1 URLs (yad1.co.il is 404)
   await runMigrationFile('Bad yad1 URL cleanup (024)', path.join(__dirname, 'db', 'migrations', '024_cleanup_bad_yad1_urls.sql'));
+  // 2026-04-30 (Day 10): retire all yad1 listings (platform defunct)
+  await runMigrationFile('Yad1 retirement (025)', path.join(__dirname, 'db', 'migrations', '025_retire_yad1_listings.sql'));
   if (isQuantum) await runOutreachMigration();
 
   loadAllRoutes();
@@ -514,7 +516,10 @@ async function start() {
     const scraperDefs = [
       { name: 'Komo',           module: './services/komoScraper',           cron: '0 8 * * *',   fn: 'scanAll' },
       { name: 'BankNadlan',     module: './services/bankNadlanScraper',     cron: '15 8 * * *',  fn: 'scanAll' },
-      { name: 'Yad1',           module: './services/yad1Scraper',           cron: '30 8 * * *',  fn: 'scanAll' },
+      // Yad1 retired 2026-04-30: yad1.co.il returns HTTP 404, the platform is defunct.
+      // Scraper was falling back to Perplexity, generating fake listings with yad2 URLs.
+      // Source file kept for reference at src/services/yad1Scraper.js but cron is off.
+      // { name: 'Yad1',           module: './services/yad1Scraper',           cron: '30 8 * * *',  fn: 'scanAll' },
       { name: 'Dira',           module: './services/diraScraper',           cron: '45 8 * * *',  fn: 'scanAll' },
       { name: 'Kones2',         module: './services/kones2Scraper',         cron: '0 9 * * *',   fn: 'scanAll' },
       { name: 'BidSpirit',      module: './services/bidspiritScraper',      cron: '15 9 * * *',  fn: 'scanAll' },

--- a/src/services/messagingOrchestrator.js
+++ b/src/services/messagingOrchestrator.js
@@ -60,7 +60,10 @@ function getPhoneOrch() {
 // exists, platform_chat for listings without phone.
 const SOURCE_CASCADE = {
   yad2:       ['whatsapp', 'yad2_chat', 'platform_link'],
-  yad1:       ['whatsapp', 'platform_chat', 'platform_link'],
+  // yad1 retired 2026-04-30 (yad1.co.il is 404). Listings deactivated by
+  // migration 025. Cascade kept here so any leftover yad1 row with a phone
+  // can still be contacted via WhatsApp if it's manually reactivated.
+  yad1:       ['whatsapp', 'platform_link'],
   dira:       ['whatsapp', 'platform_chat', 'platform_link'],
   homeless:   ['whatsapp', 'platform_chat', 'platform_link'],
   madlan:     ['whatsapp', 'platform_chat', 'platform_link'],


### PR DESCRIPTION
yad1.co.il returns HTTP 404. Scraper was falling back to Perplexity which generated fake listings.

## Changes
- `src/index.js` scraperDefs: yad1 cron commented out (source file kept for reference)
- Migration 025: deactivates all existing yad1 listings (soft delete)
- Orchestrator: yad1 cascade trimmed (removed platform_chat since URL is null)

## Coverage impact
**Zero.** yad2 scrapes the same listings — yad2 mirrors yad1's feed.

## Risk: low
- Cron just stops
- Soft delete: easy to reactivate via SQL if yad1 revives
- Orchestrator only affects now-inactive source