### PR TITLE
Day 10: ai_scan — require phone or URL + cleanup existing uncontactable rows

### DIFF
--- a/src/db/migrations/026_cleanup_ai_scan_listings.sql
+++ b/src/db/migrations/026_cleanup_ai_scan_listings.sql
@@ -1,0 +1,20 @@
+-- Migration 026: deactivate existing ai_scan listings without contact info (Day 10).
+--
+-- claudeOrchestrator.js was creating listings with source='ai_scan' but the
+-- AI prompt didn't ask for phone or URL, and the INSERT didn't save them
+-- either. Result: ~13 ai_scan listings in production with no phone AND
+-- no URL — uncontactable.
+--
+-- Going forward (this PR), the prompt asks for phone+url and the INSERT
+-- saves them; processListingFromAI also skips listings missing both.
+--
+-- This migration deactivates the existing uncontactable rows. Soft delete
+-- so they're easy to reactivate if AI scan re-finds them with better data.
+
+UPDATE listings
+SET is_active = FALSE,
+    updated_at = NOW()
+WHERE source = 'ai_scan'
+  AND is_active = TRUE
+  AND (phone IS NULL OR phone = '')
+  AND (url IS NULL OR url = '');

--- a/src/index.js
+++ b/src/index.js
@@ -386,6 +386,8 @@ async function start() {
   await runMigrationFile('Bad yad1 URL cleanup (024)', path.join(__dirname, 'db', 'migrations', '024_cleanup_bad_yad1_urls.sql'));
   // 2026-04-30 (Day 10): retire all yad1 listings (platform defunct)
   await runMigrationFile('Yad1 retirement (025)', path.join(__dirname, 'db', 'migrations', '025_retire_yad1_listings.sql'));
+  // 2026-04-30 (Day 10): deactivate ai_scan listings without contact info
+  await runMigrationFile('AI scan cleanup (026)', path.join(__dirname, 'db', 'migrations', '026_cleanup_ai_scan_listings.sql'));
   if (isQuantum) await runOutreachMigration();
 
   loadAllRoutes();

--- a/src/services/claudeOrchestrator.js
+++ b/src/services/claudeOrchestrator.js
@@ -219,7 +219,7 @@ ${complex.addresses ? `כתובות: ${complex.addresses}` : ''}
   "planned_units": מספר,
   "local_committee_date": "YYYY-MM-DD או null",
   "district_committee_date": "YYYY-MM-DD או null",
-  "listings": [{"address": "...", "price": מספר, "rooms": מספר, "sqm": מספר}],
+  "listings": [{"address": "...", "price": מספר, "rooms": מספר, "sqm": מספר, "phone": "מספר טלפון או null", "url": "URL מלא של המודעה או null", "contact_name": "שם איש קשר או null"}],
   "recent_news": "סיכום חדשות",
   "sources": ["רשימת מקורות"]
 }`;
@@ -437,8 +437,20 @@ async function processListingFromAI(listing, complexId, city) {
   const rooms = parseFloat(listing.rooms) || null;
   const sqm = parseFloat(listing.sqm || listing.area_sqm) || null;
   const address = listing.address || '';
+  const phone = listing.phone && String(listing.phone).trim() && listing.phone !== 'null' ? String(listing.phone).trim() : null;
+  const url = listing.url && String(listing.url).trim() && listing.url !== 'null' ? String(listing.url).trim() : null;
+  const contactName = listing.contact_name && listing.contact_name !== 'null' ? listing.contact_name : null;
 
   if (!price || !address) return;
+
+  // Day 10: skip listings without ANY contact mechanism. AI-generated rows
+  // with no phone and no URL are noise — operator can't reach them.
+  // The prompt now asks for phone + url; if AI couldn't find either,
+  // the listing is unusable for outreach.
+  if (!phone && !url) {
+    logger.debug(`[AIScan] skip ${address}: no phone, no URL`);
+    return;
+  }
 
   const pricePsm = (price && sqm) ? Math.round(price / sqm) : null;
   const sourceId = `ai-${complexId}-${address}-${price}`;
@@ -447,10 +459,11 @@ async function processListingFromAI(listing, complexId, city) {
     `INSERT INTO listings (
       complex_id, source, source_listing_id,
       asking_price, rooms, area_sqm, price_per_sqm,
-      address, city, first_seen, last_seen, is_active
-    ) VALUES ($1, 'ai_scan', $2, $3, $4, $5, $6, $7, $8, CURRENT_DATE, CURRENT_DATE, TRUE)
+      address, city, phone, contact_name, url,
+      first_seen, last_seen, is_active
+    ) VALUES ($1, 'ai_scan', $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, CURRENT_DATE, CURRENT_DATE, TRUE)
     ON CONFLICT DO NOTHING`,
-    [complexId, sourceId, price, rooms, sqm, pricePsm, address, city]
+    [complexId, sourceId, price, rooms, sqm, pricePsm, address, city, phone, contactName, url]
   );
 }
 

--- a/src/services/messagingOrchestrator.js
+++ b/src/services/messagingOrchestrator.js
@@ -74,6 +74,10 @@ const SOURCE_CASCADE = {
   banknadlan: ['platform_link'],          // auctions: attorney email contact, no phone
   bidspirit:  ['platform_link'],          // auction site: bid form, no chat API
   govmap:     ['platform_link'],          // government records, no contact
+  // ai_scan: AI-discovered listings via claudeOrchestrator. Whatever URL the
+  // AI returns may be on any platform, so we can't claim platform_chat.
+  // Just WhatsApp (if phone) and platform_link (manual fallback).
+  ai_scan:    ['whatsapp', 'platform_link'],
   kones:           ['sms', 'whatsapp', 'platform_link'],
   receivership:    ['sms', 'whatsapp', 'platform_link'],
   konesonline:     ['sms', 'whatsapp', 'platform_link'],


### PR DESCRIPTION
claudeOrchestrator (Perplexity+Claude) was creating ai_scan listings without phone or URL — uncontactable noise.

## Fixes
1. Prompt now asks for phone + url + contact_name
2. `processListingFromAI` saves those fields and skips listings missing both
3. Orchestrator: ai_scan cascade = whatsapp → platform_link
4. Migration 026: deactivates existing ai_scan rows without contact info (~13 rows, soft delete)

## Risk: low
Validation only adds skip; migration is soft delete on uncontactable rows.