### PR TITLE
Day 10: WhatsApp delivery tracking (DLR cron + status columns)

### DIFF
--- a/src/cron/whatsappDLRCron.js
+++ b/src/cron/whatsappDLRCron.js
@@ -1,0 +1,128 @@
+/**
+ * WhatsApp Delivery Receipt (DLR) Cron — Day 10.
+ *
+ * Polls INFORU's DeliveryNotificationWhatsapp pull endpoint every 60s and
+ * updates per-message status: sent → delivered → read (or failed).
+ *
+ * INFORU echoes back our CustomerMessageId for each delivery report, so we
+ * match each DLR to the row in sent_messages and unified_messages by
+ * external_id.
+ *
+ * Status mapping (defensive against INFORU's mixed casing/naming):
+ *   delivered / Delivered / 2     → status='delivered', delivered_at=now
+ *   read      / Read       / 3    → status='read',      read_at=now
+ *   sent      / Sent       / 1    → no-op (already 'sent')
+ *   failed / undelivered / 4 / 5  → status='failed',    failed_at=now
+ *   anything else                 → logged at debug, ignored
+ */
+const inforu = require('../services/inforuService');
+const pool = require('../db/pool');
+const { logger } = require('../services/logger');
+
+let _running = false;
+
+function classify(rawStatus) {
+  if (!rawStatus && rawStatus !== 0) return null;
+  const s = String(rawStatus).toLowerCase();
+  if (s === 'delivered' || s === '2') return 'delivered';
+  if (s === 'read'      || s === '3') return 'read';
+  if (s === 'sent'      || s === '1') return 'sent';
+  if (s === 'failed' || s === 'undelivered' || s === 'rejected' || s === '4' || s === '5' || s === '6') return 'failed';
+  return null;
+}
+
+async function applyDlr(externalId, classified, reason) {
+  if (!externalId || !classified) return { matched: 0 };
+
+  const tsField = classified === 'delivered' ? 'delivered_at'
+    : classified === 'read' ? 'read_at'
+    : classified === 'failed' ? 'failed_at'
+    : null;
+
+  // sent_messages
+  let r1 = { rowCount: 0 };
+  try {
+    r1 = await pool.query(
+      tsField
+        ? `UPDATE sent_messages SET status = $1, ${tsField} = NOW(), dlr_reason = COALESCE($3, dlr_reason) WHERE external_id = $2 RETURNING id`
+        : `UPDATE sent_messages SET status = $1, dlr_reason = COALESCE($3, dlr_reason) WHERE external_id = $2 RETURNING id`,
+      [classified, externalId, reason || null]
+    );
+  } catch (e) { logger.debug('[DLRCron] sent_messages update failed', { error: e.message }); }
+
+  // unified_messages (kept in sync; some sends only touch this table)
+  let r2 = { rowCount: 0 };
+  try {
+    r2 = await pool.query(
+      tsField
+        ? `UPDATE unified_messages SET status = $1, ${tsField} = NOW(), dlr_reason = COALESCE($3, dlr_reason), updated_at = NOW() WHERE external_id = $2 RETURNING id`
+        : `UPDATE unified_messages SET status = $1, dlr_reason = COALESCE($3, dlr_reason), updated_at = NOW() WHERE external_id = $2 RETURNING id`,
+      [classified, externalId, reason || null]
+    );
+  } catch (e) { logger.debug('[DLRCron] unified_messages update failed', { error: e.message }); }
+
+  return { matched: (r1.rowCount || 0) + (r2.rowCount || 0) };
+}
+
+function pickField(obj, ...names) {
+  for (const n of names) {
+    if (obj[n] !== undefined && obj[n] !== null) return obj[n];
+  }
+  return null;
+}
+
+async function pollDlr() {
+  if (_running) return { skipped: 'already_running' };
+  _running = true;
+
+  try {
+    const resp = await inforu.pullWhatsAppDLR(100);
+    if (!resp || resp.StatusId !== 1) return { ok: true, fetched: 0 };
+
+    // INFORU response shape isn't fully documented; try common keys.
+    const items = resp.Data?.Notifications
+      || resp.Data?.Messages
+      || resp.Data?.List
+      || resp.Data
+      || [];
+
+    const list = Array.isArray(items) ? items : [];
+    if (list.length === 0) return { ok: true, fetched: 0 };
+
+    let updated = 0, skipped = 0;
+    for (const dlr of list) {
+      const externalId = pickField(dlr,
+        'CustomerMessageId', 'customerMessageId', 'customer_message_id',
+        'MessageId', 'messageId'
+      );
+      const rawStatus = pickField(dlr,
+        'Status', 'status', 'DeliveryStatus', 'deliveryStatus', 'StatusId'
+      );
+      const reason = pickField(dlr,
+        'StatusDescription', 'statusDescription', 'Reason', 'reason'
+      );
+
+      const classified = classify(rawStatus);
+      if (!externalId || !classified) {
+        skipped++;
+        continue;
+      }
+
+      const r = await applyDlr(externalId, classified, reason);
+      if (r.matched > 0) updated++;
+      else skipped++;
+    }
+
+    if (updated > 0 || skipped > 0) {
+      logger.info('[DLRCron] poll complete', { fetched: list.length, updated, skipped });
+    }
+    return { ok: true, fetched: list.length, updated, skipped };
+  } catch (err) {
+    logger.warn('[DLRCron] poll failed', { error: err.message });
+    return { ok: false, error: err.message };
+  } finally {
+    _running = false;
+  }
+}
+
+module.exports = { pollDlr, classify };

--- a/src/db/migrations/027_whatsapp_dlr.sql
+++ b/src/db/migrations/027_whatsapp_dlr.sql
@@ -1,0 +1,29 @@
+-- Migration 027: WhatsApp delivery tracking columns (Day 10).
+--
+-- Lets the new whatsappDLRCron poll INFORU's DeliveryNotificationWhatsapp
+-- pull endpoint and persist the per-message status: delivered / read /
+-- failed, so the dashboard can show ✓ vs ✓✓ vs blue ✓✓.
+--
+-- INFORU echoes back our CustomerMessageId in each DLR row, so we save it
+-- as the lookup key (external_id on sent_messages, also on unified_messages).
+
+-- sent_messages: add external_id (customerMessageId) + delivery columns
+ALTER TABLE sent_messages
+  ADD COLUMN IF NOT EXISTS external_id    TEXT,
+  ADD COLUMN IF NOT EXISTS delivered_at   TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS read_at        TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS failed_at      TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS dlr_reason     TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_sent_messages_external_id
+  ON sent_messages (external_id) WHERE external_id IS NOT NULL;
+
+-- unified_messages: external_id + delivered_at already partially exist.
+-- Make sure they're present (idempotent).
+ALTER TABLE unified_messages
+  ADD COLUMN IF NOT EXISTS delivered_at   TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS failed_at      TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS dlr_reason     TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_unified_messages_external_id
+  ON unified_messages (external_id) WHERE external_id IS NOT NULL;

--- a/src/index.js
+++ b/src/index.js
@@ -388,6 +388,8 @@ async function start() {
   await runMigrationFile('Yad1 retirement (025)', path.join(__dirname, 'db', 'migrations', '025_retire_yad1_listings.sql'));
   // 2026-04-30 (Day 10): deactivate ai_scan listings without contact info
   await runMigrationFile('AI scan cleanup (026)', path.join(__dirname, 'db', 'migrations', '026_cleanup_ai_scan_listings.sql'));
+  // 2026-04-30 (Day 10): WhatsApp delivery tracking (DLR cron)
+  await runMigrationFile('WhatsApp DLR (027)', path.join(__dirname, 'db', 'migrations', '027_whatsapp_dlr.sql'));
   if (isQuantum) await runOutreachMigration();
 
   loadAllRoutes();
@@ -456,6 +458,13 @@ async function start() {
       cron.schedule('* * * * *', async () => { try { await pollIncomingWhatsApp(); } catch (e) {} });
       logger.info('[IncomingWA] ACTIVE - polling INFORU every 60s');
     } catch (e) { logger.warn('[IncomingWA] Failed:', e.message); }
+
+    try {
+      const { pollDlr } = require('./cron/whatsappDLRCron');
+      const cron = require('node-cron');
+      cron.schedule('* * * * *', async () => { try { await pollDlr(); } catch (e) {} });
+      logger.info('[WhatsAppDLR] ACTIVE - polling INFORU delivery receipts every 60s');
+    } catch (e) { logger.warn('[WhatsAppDLR] Failed:', e.message); }
 
     try {
       const cron = require('node-cron');

--- a/src/services/inforuService.js
+++ b/src/services/inforuService.js
@@ -512,8 +512,9 @@ async function logMessage(result, message, phones, options = {}) {
   try {
     await pool.query(`CREATE TABLE IF NOT EXISTS sent_messages (id SERIAL PRIMARY KEY, phone VARCHAR(20), message TEXT, template_key VARCHAR(50), status VARCHAR(20), status_code INTEGER, status_description TEXT, listing_id INTEGER, complex_id INTEGER, channel VARCHAR(20) DEFAULT 'sms', template_id VARCHAR(50), sender VARCHAR(50) DEFAULT 'QUANTUM', created_at TIMESTAMP DEFAULT NOW())`);
     for (const phone of phones) {
-      await pool.query(`INSERT INTO sent_messages (phone, message, template_key, status, status_code, status_description, listing_id, complex_id, channel, template_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
-        [phone, message.substring(0, 500), options.templateKey || null, result.success ? 'sent' : 'failed', result.status, result.description, options.listingId || null, options.complexId || null, options.channel || 'sms', result.templateId || null]);
+      // Day 10: persist customerMessageId as external_id so DLR cron can match
+      await pool.query(`INSERT INTO sent_messages (phone, message, template_key, status, status_code, status_description, listing_id, complex_id, channel, template_id, external_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+        [phone, message.substring(0, 500), options.templateKey || null, result.success ? 'sent' : 'failed', result.status, result.description, options.listingId || null, options.complexId || null, options.channel || 'sms', result.templateId || null, result.customerMessageId || null]);
     }
   } catch (err) { logger.warn('Failed to log message', { error: err.message }); }
 }

--- a/src/services/messagingOrchestrator.js
+++ b/src/services/messagingOrchestrator.js
@@ -351,6 +351,8 @@ async function sendToListing(listing, messageText, options = {}) {
               });
               result.success = waResult.success !== false;
               result.inforu_channel = waResult.channel; // 'whatsapp_chat' or 'sms'
+              // Day 10: persist customerMessageId so DLR cron can mark delivered/read.
+              if (waResult.customerMessageId) result.external_id = waResult.customerMessageId;
               if (!result.success) result.error = waResult.description || waResult.error;
             } catch (e) {
               // InForu failed entirely, generate link as fallback
@@ -425,8 +427,8 @@ async function sendToListing(listing, messageText, options = {}) {
       : (result.pending_manual ? 'pending_manual'
       : (result.manual_url ? 'manual' : 'failed')));
     await pool.query(
-      `UPDATE unified_messages SET status = $1, error_message = $2, channel = $3, updated_at = NOW() WHERE id = $4`,
-      [finalStatus, result.error, result.channel, result.message_id]
+      `UPDATE unified_messages SET status = $1, error_message = $2, channel = $3, external_id = COALESCE($5, external_id), updated_at = NOW() WHERE id = $4`,
+      [finalStatus, result.error, result.channel, result.message_id, result.external_id || null]
     ).catch(() => {
       pool.query(
         `UPDATE listing_messages SET status = $1, error_message = $2, channel = $3 WHERE id = $4`,


### PR DESCRIPTION
Adds the missing piece — operator now sees whether messages were delivered/read, not just 'sent to INFORU'.

## What's missing today
INFORU exposes `DeliveryNotificationWhatsapp` pull endpoint with delivery+read receipts, but no cron polls it. `pullWhatsAppDLR()` exists in inforuService and is unused. So all messages stuck at status='sent' regardless of whether they ever reached the recipient.

## What lands here
- Migration 027: external_id + delivered_at + read_at + failed_at + dlr_reason on sent_messages and unified_messages
- New whatsappDLRCron: every 60s polls INFORU, matches by customerMessageId → external_id
- inforuService.logMessage persists customerMessageId
- messagingOrchestrator captures customerMessageId on unified_messages

## Status flow after merge
sent → delivered → read     (or failed at any step)

## Risk: low
- Pure additive: new cron, new columns, defensive parsing
- logMessage signature unchanged (back-compat for older callers)
- Cron failures are logged and retried, no impact on send path

## Next (separate PR)
Dashboard render: ✓ sent, ✓✓ delivered, blue ✓✓ read. Conversation badges ("📨 נשלח" / "✅ נמסר" / "👁 נקרא").