### PR TITLE
feat(scan): unified "סריקה מלאה" button + actually run discovery (supersedes #37)

### DIFF
--- a/src/jobs/weeklyScanner.js
+++ b/src/jobs/weeklyScanner.js
@@ -290,11 +290,13 @@ async function sendScanStatusNotification(result) {
  * (since it runs every 24h, anything >20h old is eligible)
  * Manual scans keep the default 72h (3 day) threshold
  * 
- * Discovery is DISABLED by default in automated scans to prevent deployment interruptions.
- * Run manual scan with includeDiscovery: true to discover new complexes.
+ * Discovery is ENABLED by default (2026-05-01): the previous "stability" concern
+ * was Railway request timeouts on long scans, which is moot since runWeeklyScan is
+ * already fully async (this function returns nothing to the HTTP caller). The audit
+ * found 23/24 newly-declared complexes were missed because discovery never ran.
  */
 async function runWeeklyScan(options = {}) {
-  const { forceAll = false, includeDiscovery = false } = options; // Changed default to false
+  const { forceAll = false, includeDiscovery = true } = options;
   if (isRunning) {
     logger.warn('Scan already running, skipping');
     return null;
@@ -484,7 +486,7 @@ async function runWeeklyScan(options = {}) {
     }
 
     // Step 7: Generate alerts
-    logger.info('Step 7/7: Generating alerts...');
+    logger.info('Step 7/8: Generating alerts...');
     let alertCount = 0;
     try {
       alertCount = await generateAlerts(beforeSnapshot);
@@ -494,11 +496,45 @@ async function runWeeklyScan(options = {}) {
       tracker.add('alerts', 'יצירת התראות', false, 'נכשל', e.message);
     }
 
+    // Step 8: Discovery (find NEW pinuy-binuy complexes via Perplexity)
+    // Runs LAST so it doesn't slow down the rest of the pipeline.
+    // discoverDaily uses citiesPerDay rotation; discoverAll for full sweep on manual scans.
+    let discoveryResults = { newAdded: 0, skipped: !includeDiscovery, citiesScanned: 0, totalDiscovered: 0 };
+    if (includeDiscovery) {
+      const discoveryService = getDiscoveryService();
+      if (discoveryService) {
+        try {
+          logger.info(`Step 8/8: Running discovery (forceAll=${forceAll} → ${forceAll ? 'discoverAll' : 'discoverDaily'})...`);
+          const dResult = forceAll
+            ? await discoveryService.discoverAll()
+            : await discoveryService.discoverDaily();
+          discoveryResults = {
+            newAdded: dResult.new_added || 0,
+            citiesScanned: dResult.cities_scanned || 0,
+            totalDiscovered: dResult.total_discovered || 0,
+            alreadyExisted: dResult.already_existed || 0,
+            skipped: false
+          };
+          tracker.add('discovery', 'גילוי מתחמים חדשים', true,
+            `${discoveryResults.citiesScanned} ערים, ${discoveryResults.newAdded} חדשים, ${discoveryResults.alreadyExisted} כפולים`);
+        } catch (e) {
+          logger.warn('Discovery failed', { error: e.message });
+          tracker.add('discovery', 'גילוי מתחמים חדשים', false, 'נכשל', e.message);
+        }
+      } else {
+        tracker.add('discovery', 'גילוי מתחמים חדשים', false, 'discoveryService לא זמין');
+      }
+    } else {
+      logger.info('Step 8/8: Discovery skipped (includeDiscovery=false)');
+      tracker.add('discovery', 'גילוי מתחמים חדשים', true, 'דולג (includeDiscovery=false)');
+    }
+
     const duration = Math.round((Date.now() - startTime) / 1000);
     const summary = `Daily scan [DIRECT API]: ${directApiResults.succeeded}/${directApiResults.total} ok, ` +
       `${directApiResults.totalNewTransactions} tx, ${directApiResults.totalNewListings} listings. ` +
       `Nadlan: ${nadlanResults.totalNew} tx. ` +
       `KonesIsrael: ${konesResults.totalListings} listings, ${konesResults.matchedComplexes} matches. ` +
+      `Discovery: ${discoveryResults.newAdded} new complexes. ` +
       `${alertCount} alerts. ${duration}s. Steps: ${tracker.successCount()}✅ ${tracker.failedCount()}❌`;
 
     lastRunResult = {
@@ -509,7 +545,7 @@ async function runWeeklyScan(options = {}) {
       benchmarks: { calculated: benchmarkResults.calculated || 0 },
       ssi: ssiResults,
       konesIsrael: konesResults,
-      discovery: { newAdded: 0, skipped: !includeDiscovery },
+      discovery: discoveryResults,
       alertsGenerated: alertCount,
       steps: tracker.getSteps(),
       summary
@@ -580,9 +616,9 @@ function startScheduler() {
     }
     
     logger.info(`Daily scan triggered: ${DAILY_CRON}`);
-    await runWeeklyScan(); // Discovery disabled by default (includeDiscovery: false)
+    await runWeeklyScan(); // Discovery enabled by default (includeDiscovery: true since 2026-05-01)
   }, { timezone: 'Asia/Jerusalem' });
-  logger.info(`Daily scanner scheduled: ${DAILY_CRON} (08:00 Israel time, Sun-Thu, no holidays) [DIRECT API MODE - Discovery disabled for stability]`);
+  logger.info(`Daily scanner scheduled: ${DAILY_CRON} (08:00 Israel time, Sun-Thu, no holidays) [DIRECT API MODE - Discovery enabled, citiesPerDay=12]`);
 }
 
 function stopScheduler() {
@@ -617,7 +653,7 @@ function getSchedulerStatus() {
     claudeConfigured: orchestrator?.isClaudeConfigured() || false,
     notificationsConfigured: notificationService.isConfigured(),
     discoveryEnabled: !!discoveryService,
-    discoverySchedule: 'Manual only (disabled in automated scans for stability)',
+    discoverySchedule: 'Daily 08:00 (12 cities/day rotation), forceAll on manual scans',
     targetCities: discoveryService?.ALL_TARGET_CITIES?.length || 0,
     targetRegions: discoveryService?.TARGET_REGIONS ? Object.keys(discoveryService.TARGET_REGIONS) : [],
     minHousingUnits: discoveryService?.MIN_HOUSING_UNITS || 12,

--- a/src/public/dashboard.html
+++ b/src/public/dashboard.html
@@ -247,7 +247,7 @@
             <h2>⚡ פעולות מהירות</h2>
             <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(170px,1fr));gap:10px;">
                 <button class="btn btn-intel" onclick="loadMorningIntelligence()">🧠 ינטליגנציה יומית</button>
-                <button class="btn btn-green" onclick="runFullScan()" style="font-weight:700;">🔍 סריקה מלאה + Enrichment</button>
+                <button class="btn btn-green" onclick="runFullScan()" style="font-weight:700;">🚀 סריקה מלאה (הכל: מתחמים + גילוי + מודעות)</button>
                 <button class="btn" onclick="refreshStats()">🔄 רענן נתונים</button>
                 <button class="btn btn-secondary" onclick="window.open('/api/docs','_blank')">📋 API Docs</button>
             </div>
@@ -804,7 +804,7 @@
             <h2>🔍 מקורות סריקה — Real Estate Data Sources</h2>
             <div class="actions-bar" style="margin-bottom:14px;">
                 <button class="btn btn-green" onclick="runAllScrapers()">▶️ הפעל את כולם</button>
-                <button class="btn btn-intel" onclick="runFullScan()">🚀 סריקה מלאה + Enrichment</button>
+                <button class="btn btn-intel" onclick="runFullScan()">🚀 סריקה מלאה (הכל: מתחמים + גילוי + מודעות)</button>
                 <button class="btn btn-secondary" onclick="loadScraperStatus()">🔄 רענן סטטוס</button>
             </div>
             <div id="scrapers-grid" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(270px,1fr));gap:14px;margin-top:14px;"></div>
@@ -2400,21 +2400,22 @@
         }
 
         async function runFullScan() {
-            if (!confirm('להפעיל סריקה מלאה כולל Enrichment (טלפון + AI)?')) return;
-            const btn = document.querySelector('[onclick="runFullScan()"]');
-            if (btn) { btn.textContent = '⏳ סורק...'; btn.disabled = true; }
+            if (!confirm('להפעיל סריקה מלאה?\n\nכולל:\n• מתחמים (nadlan + עדכוני סטטוסים + IAI/SSI)\n• גילוי מתחמים חדשים (Perplexity)\n• מודעות (yad2/komo/dira/...) + Enrichment\n\nמשך משוער: 5-10 דקות. ירוץ ברקע — תוכל לסגור את החלון.')) return;
+            const buttons = document.querySelectorAll('[onclick="runFullScan()"]');
+            buttons.forEach(b => { b.dataset.originalText = b.textContent; b.textContent = '⏳ סריקה רצה ברקע...'; b.disabled = true; });
             try {
-                const res = await fetch('/api/scan/full', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ limit: 50 }) });
+                const res = await fetch('/api/scan/everything', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({}) });
                 const d = await res.json();
                 if (res.ok) {
-                    alert('✅ סריקה הושלמה: ' + (d.newListings||0) + ' חדשות | ' + (d.enriched||0) + ' הועשרו | ' + (d.phones||0) + ' טלפונים');
-                    refreshStats();
-            loadStatsFromAPI();
+                    alert('✅ סריקה מלאה הופעלה!\n\nscan_id: ' + (d.scan_id || '?') + '\nETA: ' + (d.eta_minutes || '5-10') + ' דקות\n\nתרוץ ברקע. השתמש ב-/api/scan/scheduler/status או רענן עוד מספר דקות לראות תוצאות.');
+                    setTimeout(() => { try { refreshStats(); loadStatsFromAPI(); } catch(_){} }, 5000);
                 } else throw new Error(d.error || 'HTTP ' + res.status);
             } catch (e) { alert('❌ שגיאה: ' + e.message); }
             finally {
-                const btn2 = document.querySelector('[onclick="runFullScan()"]');
-                if (btn2) { btn2.textContent = '🚀 סריקה מלאה + Enrichment'; btn2.disabled = false; }
+                document.querySelectorAll('[onclick="runFullScan()"]').forEach(b => {
+                    b.textContent = b.dataset.originalText || '🚀 סריקה מלאה';
+                    b.disabled = false;
+                });
             }
         }
 

--- a/src/routes/scan.js
+++ b/src/routes/scan.js
@@ -855,6 +855,86 @@ router.post('/banknadlan', async (req, res) => {
   }
 });
 
+// POST /api/scan/everything - UNIFIED full scan: complexes pipeline + listings pipeline + discovery
+// This is the canonical "סריקה מלאה" button. Runs:
+//   1. runWeeklyScan({forceAll: true, includeDiscovery: true}) — nadlan + mavat-update + IAI/SSI + discovery
+//   2. runFullScan() — listings scrapers (yad2/komo/dira/...) + phone + AI enrichment
+// Returns 202 immediately with scan_id; both pipelines run async sequentially.
+router.post('/everything', async (req, res) => {
+  try {
+    const { skipListings = false, skipComplexes = false } = req.body || {};
+    const scanLog = await pool.query(
+      `INSERT INTO scan_logs (scan_type, status) VALUES ('unified_full', 'running') RETURNING *`
+    );
+    const scanId = scanLog.rows[0].id;
+    res.json({
+      message: 'Unified full scan triggered (complexes pipeline + listings pipeline + discovery)',
+      scan_id: scanId,
+      includes: {
+        complexes_pipeline: !skipComplexes,
+        listings_pipeline: !skipListings,
+        discovery: !skipComplexes
+      },
+      eta_minutes: '5-10'
+    });
+    (async () => {
+      const startedAt = Date.now();
+      const aggregate = { complexes: null, listings: null, errors: [] };
+      try {
+        if (!skipComplexes) {
+          logger.info('[Everything] Phase 1/2: complexes pipeline + discovery (runWeeklyScan forceAll, includeDiscovery)');
+          try {
+            const { runWeeklyScan } = require('../jobs/weeklyScanner');
+            aggregate.complexes = await runWeeklyScan({ forceAll: true, includeDiscovery: true });
+          } catch (err) {
+            aggregate.errors.push(`complexes: ${err.message}`);
+            logger.error('[Everything] complexes pipeline failed', { error: err.message });
+          }
+        }
+        if (!skipListings) {
+          logger.info('[Everything] Phase 2/2: listings pipeline (runFullScan)');
+          try {
+            const { runFullScan } = require('../services/fullScanOrchestrator');
+            aggregate.listings = await runFullScan({ enrichPhones: true, enrichAi: true });
+          } catch (err) {
+            aggregate.errors.push(`listings: ${err.message}`);
+            logger.error('[Everything] listings pipeline failed', { error: err.message });
+          }
+        }
+        const durationSec = Math.round((Date.now() - startedAt) / 1000);
+        const newComplexes = aggregate.complexes?.discovery?.newAdded || 0;
+        const newListings = aggregate.listings?.total_new || 0;
+        const updatedListings = aggregate.listings?.total_updated || 0;
+        const phones = aggregate.listings?.phone_enrichment?.enriched || 0;
+        const summary =
+          `Unified scan in ${durationSec}s: ` +
+          `${newComplexes} new complexes, ${newListings} new listings, ${updatedListings} updated, ` +
+          `${phones} phones enriched. Errors: ${aggregate.errors.length || 0}.`;
+        await pool.query(
+          `UPDATE scan_logs SET status = $1, completed_at = NOW(), complexes_scanned = $2, summary = $3, errors = $4 WHERE id = $5`,
+          [
+            aggregate.errors.length ? 'partial' : 'completed',
+            newComplexes + newListings + updatedListings,
+            summary,
+            aggregate.errors.length ? aggregate.errors.join(' | ') : null,
+            scanId
+          ]
+        );
+        logger.info(`[Everything] Done in ${durationSec}s — ${summary}`);
+      } catch (err) {
+        await pool.query(
+          `UPDATE scan_logs SET status = 'failed', completed_at = NOW(), errors = $1 WHERE id = $2`,
+          [err.message, scanId]
+        );
+        logger.error('[Everything] Unified scan crashed', { error: err.message, stack: err.stack });
+      }
+    })();
+  } catch (err) {
+    logger.error('Failed to trigger /api/scan/everything', { error: err.message });
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // POST /api/scan/full - Full scan across all platforms + phone enrichment
 router.post('/full', async (req, res) => {
   try {

--- a/src/services/discoveryService.js
+++ b/src/services/discoveryService.js
@@ -24,7 +24,8 @@ const TARGET_REGIONS = {
   'שרון': ['רעננה', 'כפר סבא', 'הוד השרון', 'הרצליה', 'נתניה', 'רמת השרון', 'כוכב יאיר'],
   'מרכז': ['פתח תקווה', 'ראשון לציון', 'רחובות', 'נס ציונה', 'לוד', 'רמלה', 'מודיעין'],
   'ירושלים': ['ירושלים', 'בית שמש', 'מבשרת ציון', 'מעלה אדומים'],
-  'חיפה והקריות': ['חיפה', 'קריית ביאליק', 'קריית מוצקין', 'קריית ים', 'קריית אתא', 'נשר', 'טירת כרמל']
+  'חיפה והקריות': ['חיפה', 'קריית ביאליק', 'קריית מוצקין', 'קריית ים', 'קריית אתא', 'נשר', 'טירת כרמל'],
+  'דרום': ['אשקלון', 'אשדוד', 'באר שבע', 'יבנה', 'באר יעקב']
 };
 
 // All target cities flat list
@@ -80,7 +81,9 @@ const MIN_HOUSING_UNITS = 24;
 function getTodaysCities() {
   const today = new Date();
   const dayOfYear = Math.floor((today - new Date(today.getFullYear(), 0, 0)) / (1000 * 60 * 60 * 24));
-  const citiesPerDay = 4;
+  // Bumped from 4 → 12 so daily discovery covers all ~38 target cities every 3-4 days
+  // instead of every 9-10 days. Cost: ~12 Perplexity sonar calls/day ≈ $0.10/day.
+  const citiesPerDay = 12;
   const startIndex = (dayOfYear * citiesPerDay) % ALL_TARGET_CITIES.length;
   const cities = [];
   for (let i = 0; i < citiesPerDay; i++) {


### PR DESCRIPTION
## Why

Audit found 23/24 newly-declared pinuy-binuy projects were missing from the analyzer. After tracing the pipeline I found two root causes:

1. **Discovery was never actually called.** `runWeeklyScan` reads `includeDiscovery` but the function never invokes `discoveryService`. Even setting the flag to `true` did nothing. This has been broken silently since the pipeline was written.
2. **\"סריקה מלאה\" button was a misnomer.** It only ran the listings/leads pipeline (yad2/komo/dira) — never touched complexes, never ran discovery. The actual \"morning scan\" pipeline (`runWeeklyScan`) had no UI button at all.

## What

### Backend

| File | Change |
|------|--------|
| `src/jobs/weeklyScanner.js` | Default `includeDiscovery: true`. Add **Step 8: Discovery** that actually invokes `discoveryService.discoverDaily()` (or `discoverAll` for `forceAll=true`). |
| `src/services/discoveryService.js` | Add `דרום` region (אשקלון, אשדוד, באר שבע, יבנה, באר יעקב). Bump `citiesPerDay` 4→12 so daily rotation covers all ~38 cities every ~3 days. |
| `src/routes/scan.js` | New `POST /api/scan/everything` — fans out to `runWeeklyScan({forceAll, includeDiscovery: true})` + `runFullScan({enrichPhones, enrichAi})`. Returns `scan_id` immediately. |

### Frontend (`src/public/dashboard.html`)

- \"🔍 סריקה מלאה + Enrichment\" → \"🚀 סריקה מלאה (הכל: מתחמים + גילוי + מודעות)\"
- `runFullScan()` now calls `/api/scan/everything` instead of `/api/scan/full`
- Confirm dialog explicitly lists the 3 phases + ETA + that it runs in background

## Why discovery was disabled \"for stability\"

The original comment said \"prevent deployment interruptions\". But `runWeeklyScan` is already fully async (called via `setImmediate`/IIFE from routes), so no HTTP timeout could cascade. The real concern was probably API spend or scan duration; both are bounded:

- Daily cost: 12 cities × ~$0.005 Perplexity = **~$0.06/day** (~$2/month)
- Daily extra duration: 12 cities × 4s delay = **~50s** (negligible vs current ~3-5min scan)

## Risks

- **discoveryService failures** isolated — Step 8 wraps in try/catch, doesn't break Steps 1-7.
- **scan_logs row stays in 'running'** for unified scan duration (5-10 min). Existing `stuckScanWatcher` (2h timeout) handles hangs.
- **Per-source diagnostic buttons unchanged** — they still hit `/api/scan/yad2` etc, useful for debugging individual scrapers.

## Supersedes #37

PR #37 was a smaller fix that only added אשקלון. This PR includes that change plus the deeper fixes. Close #37 once this lands.

## Manual verification after merge

\`\`\`bash
# Trigger one unified scan
curl -X POST https://pinuy-binuy-analyzer-production.up.railway.app/api/scan/everything

# Check status (returns running/completed/partial)
curl https://pinuy-binuy-analyzer-production.up.railway.app/api/scan/scheduler/status

# Verify discovery step ran:
# logs should show "Step 8/8: Running discovery (forceAll=true → discoverAll)"
# discovery section in result should show citiesScanned > 0, newAdded > 0
\`\`\`

## Follow-ups (not this PR)

- [ ] Replace Perplexity-based mavat with real CKAN API integration (mavat.iplan.gov.il/data.gov.il)
- [ ] Add RSS feed monitoring for רשות ההתחדשות העירונית
- [ ] Manual stub-insert for declarations Perplexity won't find (e.g., ברל לוקר ירושלים — 64→237 units, very specific)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)