### PR TITLE
fix(komo): only save pinuy-binuy listings + cleanup retro (migration 030)

### DIFF
--- a/src/db/migrations/030_cleanup_komo_non_pinuy_binuy.sql
+++ b/src/db/migrations/030_cleanup_komo_non_pinuy_binuy.sql
@@ -1,0 +1,22 @@
+-- Migration 030: deactivate komo listings that aren't pinuy-binuy.
+--
+-- komoDirectScraper.js scrapes ALL apartment-for-sale listings from
+-- komo.co.il for cities in TARGET_REGIONS, but unlike yad2/yad1/dira/
+-- winwin/homeless/banknadlan it never filtered to pinuy-binuy complexes.
+-- Result: the listings table is polluted with komo rows that have
+-- complex_id = NULL — irrelevant to pinuy-binuy lead generation.
+--
+-- Going forward (this PR), saveListing() in komoDirectScraper calls
+-- findMatchingComplex() and skips listings without a match, in parity
+-- with the other scrapers.
+--
+-- This migration soft-deletes the existing polluting rows. Soft delete
+-- (is_active=FALSE) so we can revive them if a future TARGET_REGIONS
+-- expansion brings their complex into scope. Same pattern as 026.
+
+UPDATE listings
+SET is_active = FALSE,
+    updated_at = NOW()
+WHERE source = 'komo'
+  AND is_active = TRUE
+  AND complex_id IS NULL;

--- a/src/index.js
+++ b/src/index.js
@@ -392,6 +392,8 @@ async function start() {
   await runMigrationFile('WhatsApp DLR (027)', path.join(__dirname, 'db', 'migrations', '027_whatsapp_dlr.sql'));
   // 2026-04-30 (Day 10): lead archive support
   await runMigrationFile('Lead archive (028)', path.join(__dirname, 'db', 'migrations', '028_lead_archive.sql'));
+  // 2026-05-01: deactivate komo listings that aren't pinuy-binuy (parity with yad2/dira/etc)
+  await runMigrationFile('Komo non-pinuy-binuy cleanup (030)', path.join(__dirname, 'db', 'migrations', '030_cleanup_komo_non_pinuy_binuy.sql'));
   if (isQuantum) await runOutreachMigration();
 
   loadAllRoutes();

--- a/src/services/komoDirectScraper.js
+++ b/src/services/komoDirectScraper.js
@@ -6,6 +6,7 @@
 const axios = require('axios');
 const pool = require('../db/pool');
 const { logger } = require('./logger');
+const { findMatchingComplex } = require('./complexMatcher');
 
 const DELAY_MS = 1500; // 1.5s between requests to be polite
 const BASE_URL = 'https://www.komo.co.il';
@@ -160,11 +161,19 @@ async function fetchListingDetails(modaaNum) {
  */
 async function saveListing(listing) {
   try {
+    // Only save listings that match a pinuy-binuy complex (parity with yad2/yad1/dira/winwin/homeless/banknadlan)
+    const match = await findMatchingComplex(listing.address, listing.city);
+    if (!match) {
+      logger.debug(`[Komo] No complex match for: ${listing.address}, ${listing.city} — skipping`);
+      return 'no_complex_match';
+    }
+    const complexId = match.complexId;
+
     const existing = await pool.query(
       `SELECT id, phone FROM listings WHERE source = 'komo' AND source_listing_id = $1`,
       [listing.source_listing_id]
     );
-    
+
     if (existing.rows.length > 0) {
       const row = existing.rows[0];
       // Update if we have new phone or price
@@ -172,26 +181,28 @@ async function saveListing(listing) {
         await pool.query(
           `UPDATE listings SET phone = $1, contact_name = COALESCE($2, contact_name),
            asking_price = COALESCE($3, asking_price), url = COALESCE($4, url),
-           last_seen = CURRENT_DATE, updated_at = NOW() WHERE id = $5`,
-          [listing.phone, listing.contact_name, listing.price, listing.url, row.id]
+           complex_id = COALESCE(complex_id, $5),
+           last_seen = CURRENT_DATE, updated_at = NOW() WHERE id = $6`,
+          [listing.phone, listing.contact_name, listing.price, listing.url, complexId, row.id]
         );
         return 'phone_updated';
       }
       if (listing.price && listing.price !== row.asking_price) {
         await pool.query(
-          `UPDATE listings SET asking_price = $1, last_seen = CURRENT_DATE, updated_at = NOW() WHERE id = $2`,
-          [listing.price, row.id]
+          `UPDATE listings SET asking_price = $1, complex_id = COALESCE(complex_id, $2),
+           last_seen = CURRENT_DATE, updated_at = NOW() WHERE id = $3`,
+          [listing.price, complexId, row.id]
         );
         return 'price_updated';
       }
       return 'skipped';
     }
-    
+
     await pool.query(
       `INSERT INTO listings (source, source_listing_id, address, city, asking_price,
         rooms, area_sqm, floor, phone, contact_name, url, description_snippet,
-        is_active, first_seen, last_seen, created_at, updated_at)
-       VALUES ('komo', $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11,
+        complex_id, is_active, first_seen, last_seen, created_at, updated_at)
+       VALUES ('komo', $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12,
         TRUE, CURRENT_DATE, CURRENT_DATE, NOW(), NOW())
        ON CONFLICT (source, LOWER(TRIM(address)), LOWER(TRIM(city)))
        DO UPDATE SET last_seen=CURRENT_DATE, asking_price=COALESCE(EXCLUDED.asking_price, listings.asking_price),
@@ -203,7 +214,7 @@ async function saveListing(listing) {
         listing.source_listing_id, listing.address, listing.city, listing.price,
         listing.rooms, listing.area_sqm, listing.floor,
         listing.phone, listing.contact_name,
-        listing.url, listing.description
+        listing.url, listing.description, complexId
       ]
     );
     return 'inserted';
@@ -232,8 +243,8 @@ async function scanCity(city, maxPages = 3) {
   allIds = [...new Set(allIds)];
   logger.info(`[KomoDirect] ${city}: ${allIds.length} unique listings to process`);
   
-  let inserted = 0, phoneUpdated = 0, priceUpdated = 0, errors = 0;
-  
+  let inserted = 0, phoneUpdated = 0, priceUpdated = 0, skippedNoMatch = 0, errors = 0;
+
   for (const modaaNum of allIds) {
     try {
       // Fetch details and phone in parallel
@@ -241,25 +252,26 @@ async function scanCity(city, maxPages = 3) {
         fetchListingDetails(modaaNum),
         fetchPhone(modaaNum)
       ]);
-      
+
       if (!details) { errors++; continue; }
-      
+
       const listing = { ...details, ...phoneData };
       const result = await saveListing(listing);
-      
+
       if (result === 'inserted') inserted++;
       else if (result === 'phone_updated') phoneUpdated++;
       else if (result === 'price_updated') priceUpdated++;
-      
+      else if (result === 'no_complex_match') skippedNoMatch++;
+
       await sleep(DELAY_MS);
     } catch (err) {
       logger.warn(`[KomoDirect] Error processing ${modaaNum}: ${err.message}`);
       errors++;
     }
   }
-  
-  logger.info(`[KomoDirect] ${city}: ${inserted} new, ${phoneUpdated} phone updated, ${priceUpdated} price updated, ${errors} errors`);
-  return { city, total: allIds.length, inserted, phoneUpdated, priceUpdated, errors };
+
+  logger.info(`[KomoDirect] ${city}: ${inserted} new, ${phoneUpdated} phone updated, ${priceUpdated} price updated, ${skippedNoMatch} skipped (not pinuy-binuy), ${errors} errors`);
+  return { city, total: allIds.length, inserted, phoneUpdated, priceUpdated, skippedNoMatch, errors };
 }
 
 /**


### PR DESCRIPTION
## Why

The audit of scrapers (during PR #38 review) revealed komo was the only listing source NOT filtering to pinuy-binuy complexes. yad2, yad1, dira, winwin, homeless, banknadlan, facebook all use `findMatchingComplex` and skip non-matches. Komo just stored every `apartments-for-sale` listing it found in target cities, polluting the listings table with non-pinuy-binuy data.

## A) Filter going forward (komoDirectScraper.js)

- Import `findMatchingComplex` from `./complexMatcher`
- `saveListing()` calls it before insert; returns `no_complex_match` and skips when no complex match
- Pass `complex_id` into the INSERT (was always NULL before)
- Update existing rows to backfill `complex_id` when newly matched
- `scanCity()` now reports `skippedNoMatch` count

## B) Cleanup retro (migration 030)

```sql
UPDATE listings SET is_active = FALSE, updated_at = NOW()
WHERE source = 'komo' AND is_active = TRUE AND complex_id IS NULL;
```

Soft delete (per 026 pattern) so we can revive if scope changes.

## Risk

- Low. Migration 030 runs once via existing `runMigrationFile` pipeline.
- If `complexMatcher` mistakenly skips a legitimate komo listing, it's silently dropped. Visible in scanCity output.

## Verification post-merge

```sql
-- Should be 0 going forward:
SELECT COUNT(*) FROM listings WHERE source='komo' AND is_active=TRUE AND complex_id IS NULL;

-- Should show how many were soft-deleted by migration 030:
SELECT COUNT(*) FROM listings WHERE source='komo' AND is_active=FALSE AND complex_id IS NULL;
```

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)