### PR TITLE
feat(synthesis): compute real price/sqm per complex from active listings

### DIFF
--- a/src/jobs/masterPipeline.js
+++ b/src/jobs/masterPipeline.js
@@ -461,7 +461,8 @@ function buildSynthesisPrompt(complex) {
 - עד תחילת בנייה: ${monthsToConstruction}
 
 ## נתוני שוק:
-- מחיר ממוצע למ"ר: ${complex.city_avg_price_sqm ? '₪' + parseInt(complex.city_avg_price_sqm).toLocaleString('he-IL') : 'לא ידוע'}
+- מחיר ממוצע למ"ר בעיר: ${complex.city_avg_price_sqm ? '₪' + parseInt(complex.city_avg_price_sqm).toLocaleString('he-IL') : 'לא ידוע'}
+- מחיר ממוצע למ"ר במתחם (מודעות פעילות): ${complex.current_avg_price_sqm ? '₪' + parseInt(complex.current_avg_price_sqm).toLocaleString('he-IL') : 'לא ידוע (אין מודעות פעילות)'}
 - יחידות מתוכננות: ${complex.planned_units || 'לא ידוע'}
 - יחידות קיימות: ${complex.existing_units || 'לא ידוע'}
 - אחוז חתימות: ${complex.signature_percent ? complex.signature_percent + '%' : 'לא ידוע'}
@@ -547,6 +548,11 @@ async function runClaudeSynthesis() {
     SELECT c.id, c.name, c.city, c.status, c.iai_score,
            c.actual_premium, c.statutory_premium_estimate,
            c.city_avg_price_sqm,
+           (SELECT ROUND(AVG(price_per_sqm))::int
+              FROM listings
+              WHERE complex_id = c.id
+                AND is_active = TRUE
+                AND price_per_sqm > 0) AS current_avg_price_sqm,
            c.planned_units, c.existing_units, c.signature_percent,
            c.local_committee_date, c.district_committee_date,
            c.is_tamal, c.is_vatmal, c.vatmal_status, c.vatmal_plan_number, c.vatmal_next_hearing,


### PR DESCRIPTION
Restores the per-complex price/sqm signal in Claude synthesis using a subquery over active listings — replaces the dead `c.price_per_sqm` reference that PR #42 had to drop to unstick the pipeline.

```sql
(SELECT ROUND(AVG(price_per_sqm))::int
   FROM listings
   WHERE complex_id = c.id AND is_active = TRUE AND price_per_sqm > 0
) AS current_avg_price_sqm
```

Prompt now distinguishes city baseline vs complex average:
- `מחיר ממוצע למ"ר בעיר` — `c.city_avg_price_sqm` (madlan)
- `מחיר ממוצע למ"ר במתחם (מודעות פעילות)` — subquery above

Falls back to `לא ידוע (אין מודעות פעילות)` when complex has 0 active listings.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)